### PR TITLE
Do not fail if properties file is not present.

### DIFF
--- a/src/org/simbrain/util/Utils.java
+++ b/src/org/simbrain/util/Utils.java
@@ -40,6 +40,8 @@ import java.util.StringTokenizer;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
 
+import org.apache.log4j.Logger;
+
 import com.Ostermiller.util.CSVParser;
 import com.Ostermiller.util.CSVPrinter;
 
@@ -47,6 +49,8 @@ import com.Ostermiller.util.CSVPrinter;
  * <b>Utils</b>. Utility class for simbrain package.
  */
 public class Utils {
+	 /** Logger. */
+    private static Logger logger = Logger.getLogger(Utils.class);
 
     /** File system separator. */
     private static final String FS = System.getProperty("file.separator");
@@ -654,9 +658,13 @@ public class Utils {
     public static Properties getSimbrainProperties() {
         try {
             Properties properties = new Properties();
-            String fs = System.getProperty("file.separator");
-            properties.load(new FileInputStream("." + fs + "etc" + fs
-                    + "config.properties"));
+            File file = new File("." + FS + "etc" + FS + "config.properties");
+            if (file.exists()) {
+	            properties.load(new FileInputStream(file));
+            }
+            else {
+            	logger.info("Could not find properties file at " + file.getAbsolutePath());
+            }
             return properties;
         } catch (IOException ex) {
             ex.printStackTrace();


### PR DESCRIPTION
I'm using Simbrain as a library in another project and have found that if there is no properties file present (in "./etc/config.properties") it fails with an exception. 

I haven't looked at other classes but org.simbrain.network.core.Synapse has the lines:

```java
Properties properties = Utils.getSimbrainProperties();
if (properties.containsKey("weightUpperBound")) {
```
so expecting at least an empty Properties object to be returned by `Utils.getSimbrainProperties()`, however `Utils.getSimbrainProperties()` returns null if the properties file is not found, causing the Synapse class to throw a NullPointerException on initialisation.

This pull request changes the behaviour of `Utils.getSimbrainProperties()` to return an empty Properties object if the config.properties file is not found. In my minimal testing (creating a loose Network consisting of SigmoidalRule and StaticSynapseRule Neurons and Synapses) this seems to work. I suppose if some other update rule or component depends on a property being defined then an exception that is at least as informative as the NullPointerException that currently gets generated will be generated.
