### PR TITLE
Add support for specifying user-editable model parameters via annotations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 *.iml
 out/*
 /bin1/
+.settings/
 
 .checkstyle

--- a/src/org/simbrain/network/gui/Parameter.java
+++ b/src/org/simbrain/network/gui/Parameter.java
@@ -1,0 +1,411 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.network.gui;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Wrapper for {@link UserParameter} annotations containing various utility methods.
+ *
+ * @author O. J. Coleman
+ */
+public class Parameter implements Comparable<Parameter> {
+	/**
+	 * TheAnnotation for this Parameter.
+	 */
+	public final UserParameter annotation;
+	
+	/**
+	 * The Field for this Parameter.
+	 */
+	public final Field field;
+	
+	
+	public Parameter(Field field) {
+		this.field = field;
+		annotation = field.getAnnotation(UserParameter.class);
+	}
+	
+	
+	/**
+	 * Returns true iff the type of the field is numeric (integer or floating-point).
+	 */
+	public boolean isNumeric() {
+		return isNumericFloat() || isNumericInteger();
+	}
+	
+	public boolean isNumericFloat() {
+		return floatTypes.contains(field.getType()); 
+	}
+	
+	public boolean isNumericInteger() {
+		return integerTypes.contains(field.getType()); 
+	}
+	
+	/**
+	 * Returns true iff the type of the field is boolean.
+	 */
+	public boolean isBoolean() {
+		return field.getType().equals(Boolean.TYPE) || field.getType().equals(Boolean.class);
+	}
+	
+	/**
+	 * Returns true iff the type of the field is String.
+	 */
+	public boolean isString() {
+		return field.getType().equals(String.class);
+	}
+	
+	/**
+	 * Returns true iff the UserParameter defines a default value.
+	 */
+	public boolean hasDefaultValue() {
+		return !"".equals(annotation.defaultValue());
+	}
+	
+	/**
+	 * Returns true iff the UserParameter defines a minimum value.
+	 */
+	public boolean hasMinValue() {
+		return !Double.isNaN(annotation.minimumValue());
+	}
+	
+	/**
+	 * Returns true iff the UserParameter defines a maximum value.
+	 */
+	public boolean hasMaxValue() {
+		return !Double.isNaN(annotation.maximumValue());
+	}
+	
+	/**
+	 * Returns the default value for this parameter, or null if none is specified.
+	 */
+	public Object getDefaultValue() {
+		if (!annotation.defaultValue().trim().equals("")) {
+			try {
+				return interpretValue(annotation.defaultValue());
+			}
+			catch (Exception e) {
+				String message = "The type of parameter field " + 
+				        field.getDeclaringClass().getSimpleName() + "." + field.getName() + 
+						" is " + field.getType().getSimpleName() + 
+						" but it looks like the default value specified, '" + 
+						annotation.defaultValue() + "', cannot be interpreted as such."; 
+				System.err.println(message);
+			}
+		}
+		
+		if (isNumeric()) {
+			// Respect/use bounds to determine default numeric value.
+			double val = 0;
+			if (hasMinValue() && hasMaxValue()) {
+				val = (annotation.maximumValue() - annotation.minimumValue()) / 2;
+			}
+			else {
+				if (hasMinValue() && val < annotation.minimumValue())
+					val = annotation.minimumValue();
+				else if (hasMaxValue() && val > annotation.maximumValue()) 
+					val = annotation.maximumValue();
+			}
+			
+			if (isNumericFloat()) return val;
+			if (isNumericInteger()) return (int) Math.round(val);
+		}
+		
+		if (isBoolean()) return false;
+		
+		if (isString()) return "";
+		
+		return null;
+	}
+	
+	
+	/**
+	 * Get the value for this parameter on an object instance.
+	 * 
+	 * @param instance The object containing the parameter field to get the value of.
+	 * 
+	 * @throws RuntimeException If a Java reflection API error occurs.
+	 * @throws NullPointerException If <em>object</em> is null.
+	 */
+	public Object getFieldValue(Object instance) {
+		try {
+			field.setAccessible(true);
+			return field.get(instance);
+		}
+		catch (Exception e) {
+			throw new RuntimeException("Something went wrong getting the value: " + e.getMessage(), e);
+		} 
+	}
+	
+
+	/**
+	 * Set the value for this parameter on an object instance.
+	 * 
+	 * @param object The object containing the parameter field to set.
+	 * @param value The value to assign to the parameter field on <em>object</em>. May not be null.
+	 * 
+	 * @throws IllegalArgumentException If an error occurs setting the value (for example it doesn't meet a validation criterion).
+	 * @throws RuntimeException If a Java reflection API error occurs.
+	 * @throws NullPointerException If <em>object</em> or <em>value</em> are null.
+	 */
+	public void setFieldValue(Object object, Object value) {
+		value = interpretValue(value);
+		
+		String validationError = validateValue(value);
+		if (validationError != null) {
+			throw new IllegalArgumentException(validationError);
+		}
+		
+		try {
+			field.setAccessible(true);
+			field.set(object, value);
+		} catch (Exception e) {
+			throw new RuntimeException("Something went wrong setting the value: " + e.getMessage(), e);
+		}
+	}
+	
+	
+	/**
+	 * Attempt to convert the given value to the type of this parameter field.
+	 * 
+	 * @param value The value to convert/interpret.
+	 * 
+	 * @throws IllegalArgumentException If the given value cannot be converted to the field type.
+	 * @throws RuntimeException If a Java reflection API error occurs.
+	 * @throws NullPointerException If <em>value</em> is null.
+	 */
+	public Object interpretValue(Object value) {
+		// This probably shouldn't happen, but it's better to let the caller 
+		// deal with it (or throw an exception for debugging purposes).
+		if (value == null) return null;
+		
+		// Get the parameter field type.
+		Class<?> fieldType = field.getType();
+		Class<?> valueType = value.getClass();
+		
+		if (fieldType.isPrimitive()) {
+			// Convert to wrapped type so we can compare with given value, 
+			// and use the constructor from the wrapper to convert from string if necessary.
+			fieldType = primitiveWrappers.get(fieldType);
+		}
+
+		if (fieldType.isAssignableFrom(valueType)) return value;
+		
+		// Convert the given value to the field type.
+		try {
+			// Find a constructor taking a single argument of the type given.
+			Constructor<?> constructor = fieldType.getConstructor(valueType);
+			if (constructor == null) {
+				// Otherwise try to find a string constructor and convert given value to String.
+				// This works around cases such as being given a Double when a Float is required, 
+				// and int/float if possible, etc.
+				constructor = fieldType.getConstructor(valueType);
+				if (constructor == null) {
+					throw new IllegalArgumentException("Value does not match the parameter field type.");
+				}
+				value = value.toString();
+			}
+			
+			value = constructor.newInstance(value);
+		} catch (NoSuchMethodException | SecurityException | InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			throw new RuntimeException("Something went wrong while interpreting the given value: " + e.getMessage(), e);
+		}
+		
+		return value;
+	}
+	
+	
+	/**
+	 * Validate the given value.
+	 * 
+	 * @param value The value to validate. Must be of a type that matches the field type.
+	 * 
+	 * @return An error message or null if the value is valid.
+	 * 
+	 * @throws NullPointerException If <em>value</em> is null.
+	 */
+	public String validateValue(Object value) {
+		// Convert if necessary (this is mostly a no-op if the value is already of the same type as the field).
+		value = interpretValue(value);
+		
+		// Validate against regex if applicable.
+		if (!annotation.regexValidation().trim().equals("") && value instanceof String) {
+			Pattern p = Pattern.compile(annotation.regexValidation().trim());
+			Matcher m = p.matcher((String) value);
+			if (!m.matches()) {
+				return "Value is invalid, it must match the regular expression /" + p.pattern() + "/.";
+			}
+		}
+		
+		// If this is a numeric type, test against the min and max values if specified.
+		if (isNumeric()) {
+			Number numericValue = (Number) value;
+			if (hasMinValue() && numericValue.doubleValue() < annotation.minimumValue()) {
+				throw new IllegalArgumentException("Value is lower than minimum allowed.");
+			}
+			if (hasMaxValue() && numericValue.doubleValue() > annotation.maximumValue()) {
+				throw new IllegalArgumentException("Value is greater than maximum allowed.");
+			}
+		}
+		
+		return null;
+	}
+	
+	
+	
+	// Static cache of annotated fields for a class.
+	// Avoids multiple runs of expensive reflection code. 
+	private static Map<Class<?>, Set<Parameter>> classParameters = new HashMap<>();
+
+	/**
+	 * Get the available {@link Parameter}s ({@link UserParameter} annotated Fields) defined in the specified class.
+	 * The available Parameters are statically cached.
+	 * 
+	 * @return The available Parameters, sorted according to {@link UserParameter#weight()}.    
+	 */
+	public static Set<Parameter> getParameters(final Class<?> paramClass) {
+		if (!classParameters.containsKey(paramClass)) {
+			Set<Parameter> params = new TreeSet<>();
+			Set<String> fieldNames = new HashSet<>();
+			
+			// Get all super-classes too so that we can set their fields.
+			for (Class<?> clazz : getSuperClasses(paramClass)) {
+				for (Field f : clazz.getDeclaredFields()) {
+					if (f.isAnnotationPresent(UserParameter.class)) {
+						if (fieldNames.contains(f.getName())) {
+							// TODO Make a special exception? Probably not, it's only for developers when making update rules etc.
+							throw new RuntimeException("A field with the same name, '" + f.getName() + "', is declared in a super-class of " + paramClass.getName());
+						}
+						
+						fieldNames.add(f.getName());
+						params.add(new Parameter(f));
+					}
+				}
+			}
+			classParameters.put(paramClass, Collections.unmodifiableSet(params));
+		}
+		
+		return classParameters.get(paramClass);
+	}
+	
+
+	/**
+	 * Gets a list containing this class and all its super-classes up to the parent ConfigurableBase. The list is
+	 * ordered from super to this class.
+	 */
+	protected static List<Class<?>> getSuperClasses(final Class<?> clazz) {
+		List<Class<?>> classes = new ArrayList<Class<?>>();
+		Class<?> superClass = clazz;
+		while (!superClass.equals(Object.class)) {
+			classes.add(superClass);
+			superClass = classes.get(classes.size() - 1).getSuperclass();
+		}
+		
+		Collections.reverse(classes);
+		return classes;
+	}
+
+	
+	/**
+	 * Mapping from primitive types to the corresponding wrapper types.
+	 */
+	protected static final Map<Class<?>, Class<?>> primitiveWrappers = new HashMap<>();
+	static {
+		primitiveWrappers.put(Boolean.TYPE, Boolean.class);
+		primitiveWrappers.put(Byte.TYPE, Byte.class);
+		primitiveWrappers.put(Character.TYPE, Character.class);
+		primitiveWrappers.put(Short.TYPE, Short.class);
+		primitiveWrappers.put(Integer.TYPE, Integer.class);
+		primitiveWrappers.put(Long.TYPE, Long.class);
+		primitiveWrappers.put(Double.TYPE, Double.class);
+		primitiveWrappers.put(Float.TYPE, Float.class);
+		primitiveWrappers.put(Void.TYPE, Void.TYPE);
+	}
+	
+	
+	/**
+	 * Set of all floating-point types.
+	 */
+	protected static final Set<Class<?>> floatTypes = new HashSet<>();
+	static {
+		floatTypes.add(Double.TYPE);
+		floatTypes.add(Double.class);
+		floatTypes.add(Float.TYPE);
+		floatTypes.add(Float.class);
+		floatTypes.add(BigDecimal.class);
+	}
+	
+	/**
+	 * Set of all integer types.
+	 */
+	protected static final Set<Class<?>> integerTypes = new HashSet<>();
+	static {
+		integerTypes.add(Byte.TYPE);
+		integerTypes.add(Byte.class);
+		integerTypes.add(Short.TYPE);
+		integerTypes.add(Short.class);
+		integerTypes.add(Integer.TYPE);
+		integerTypes.add(Integer.class);
+		integerTypes.add(Long.class);
+		integerTypes.add(Long.class);
+	}
+	
+	
+	/**
+	 * Impose ordering by {@link UserParameter#order()} and then field name.
+	 */ 
+	@Override
+	public int compareTo(Parameter other) {
+		int result = Integer.compare(this.annotation.order(), other.annotation.order());
+		if (result != 0) return result;
+		return this.field.getName().compareTo(other.field.getName());
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof Parameter) {
+			return field.equals(((Parameter) other).field);
+		}
+		return false;
+	}
+	
+	@Override
+	public int hashCode() {
+		return field.hashCode();
+	}
+	
+	@Override
+	public String toString() {
+		return "Parameter " + annotation.label();
+	}
+}

--- a/src/org/simbrain/network/gui/ParameterWidget.java
+++ b/src/org/simbrain/network/gui/ParameterWidget.java
@@ -1,0 +1,200 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.network.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.swing.JComponent;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+
+import org.simbrain.util.widgets.JNumberSpinnerWithNull;
+import org.simbrain.util.widgets.SpinnerNumberModelWithNull;
+import org.simbrain.util.widgets.YesNoNull;
+
+/**
+ * A wrapper class for a {@link Parameter} and an associated GUI widget (JComponent).
+ *
+ * @author O. J. Coleman
+ */
+public class ParameterWidget implements Comparable<ParameterWidget> {
+	/**
+	 * The parameter for this widget.
+	 */
+	public final Parameter parameter;
+	
+	/**
+	 * The GUI element for this widget.
+	 */
+	public final JComponent component;
+	
+	
+	public ParameterWidget(Parameter param) {
+		parameter = param;
+		component = makeWidget();
+	}
+	
+	
+	/**
+	 * Create an appropriate widget for this parameter.
+	 */
+	protected JComponent makeWidget() {
+		if (parameter.isBoolean()) {
+			return new YesNoNull();
+		}
+		
+		if (parameter.isNumeric()) {
+			Number defaultValue = (Number) parameter.getDefaultValue();
+			
+			SpinnerNumberModelWithNull spinnerModel;
+			
+			Double minValue = parameter.hasMinValue() ? parameter.annotation.minimumValue() : null;
+			Double maxValue = parameter.hasMaxValue() ? parameter.annotation.maximumValue() : null;
+			double range;
+			double stepSize = 0.1;
+			
+			// If there's a min and/or max value then we can base the spinner step size on it.
+			if (minValue != null || maxValue != null || defaultValue != null) {
+				if (minValue != null && maxValue != null) {
+					range = maxValue.doubleValue() - minValue.doubleValue();
+				}
+				else if (minValue != null) {
+					range = Math.abs(minValue.doubleValue());
+				}
+				else if (maxValue != null) {
+					range = Math.abs(maxValue.doubleValue());
+				}
+				else {
+					range = Math.abs(defaultValue.doubleValue());
+				}
+				
+				double initialStep = range / 100; // aiming for about 100 steps between min and max.
+				double magnitude = Math.pow(10, Math.floor(Math.log10(initialStep)));
+				double msd = initialStep / magnitude;
+		        if (msd > 5)
+		            msd = 10;
+		        else if (msd > 2)
+		            msd = 5;
+		        else if (msd > 1)
+		            msd = 2;
+		        stepSize = msd * magnitude;
+			}
+			
+			if (parameter.isNumericInteger()) {
+				int step = (int) Math.max(1, stepSize);
+				spinnerModel = new SpinnerNumberModelWithNull(
+						(Integer) defaultValue, 
+						minValue ==  null ? null : minValue.intValue(), 
+						maxValue ==  null ? null : maxValue.intValue(), 
+						step);
+			}
+			else {
+				spinnerModel = new SpinnerNumberModelWithNull((Double) defaultValue, minValue, maxValue, stepSize);
+			}
+			
+			return new JNumberSpinnerWithNull(spinnerModel);
+		}
+		
+		return new JTextField();
+	}
+	
+
+	/**
+	 * Returns tooltip text for this parameter.
+	 */
+	public String getToolTipText() {
+		UserParameter anot = parameter.annotation;
+		List<String> tips = new ArrayList<>();
+		if (!"".equals(anot.description())) {
+			tips.add(anot.description());
+		}
+		if (parameter.hasDefaultValue()) {
+			tips.add("Default: " + parameter.getDefaultValue());
+		}
+		if (parameter.hasMinValue()) {
+			tips.add("Minimum: " + (parameter.isNumericInteger() ? ""+((int) anot.minimumValue()) :  ""+anot.minimumValue()));
+		}
+		if (parameter.hasMaxValue()) {
+			tips.add("Maximum: " + (parameter.isNumericInteger() ? ""+((int) anot.maximumValue()) :  ""+anot.maximumValue()));
+		}
+		if (tips.isEmpty()) return "";
+		return "<html>" + tips.stream().collect(Collectors.joining("<br/>")) + "</html>";
+	}
+	
+	
+	/**
+	 * Set the value of the widget.
+	 */
+	public void setWidgetValue(Object value) {
+		if (parameter.isBoolean()) {
+			if (value == null) {
+				((YesNoNull) component).setNull();
+			}
+			else {
+				((YesNoNull) component).setSelected((Boolean) value);
+			}
+		}
+		else if (parameter.isNumeric()) {
+			((JNumberSpinnerWithNull) component).setValue(value);
+		}
+		else {
+			((JTextField) component).setText(value == null ? "" : value.toString());
+		}
+	}
+	
+	
+	/**
+	 * Get the value of the widget.
+	 */
+	public Object getWidgetValue() {
+		if (parameter.isBoolean()) {
+			return ((YesNoNull) component).isNull() ? null : ((YesNoNull) component).isSelected();
+		}
+		if (parameter.isNumeric()) {
+			return ((JNumberSpinnerWithNull) component).getValue();
+		}
+		else {
+			return ((JTextField) component).getText();
+		}
+	}
+	
+	
+	/**
+	 * Impose ordering by {@link UserParameter#order()} and then field name.
+	 */ 
+	@Override
+	public int compareTo(ParameterWidget other) {
+		return this.parameter.compareTo(other.parameter);
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		if (other instanceof ParameterWidget) {
+			return parameter.equals(((ParameterWidget) other).parameter);
+		}
+		return false;
+	}
+	
+	@Override
+	public int hashCode() {
+		return parameter.hashCode();
+	}
+}

--- a/src/org/simbrain/network/gui/UserParameter.java
+++ b/src/org/simbrain/network/gui/UserParameter.java
@@ -1,0 +1,95 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.network.gui;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.simbrain.util.math.ProbDistribution;
+
+/**
+ * Annotation for user-configurable parameter fields that provides for specifying meta-data such as label, description,
+ * and validation criteria. This information may be used by dialog builders to construct input fields.
+ * 
+ * @author O. J. Coleman
+ */
+@Documented
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UserParameter {
+	/**
+	 * Label for the parameter.
+	 */
+	String label();
+
+	/**
+	 * Description for the parameter.
+	 */
+	String description() default "";
+
+	/**
+	 * Whether the parameter is optional. Note that if a defaultValue is 
+	 * specified then this will be used even if optional is set.
+	 */
+	boolean optional() default false;
+
+	/**
+	 * A default value for the parameter.
+	 */
+	String defaultValue() default "";
+
+	/**
+	 * For numeric types, a minimum value, inclusive. Optional.
+	 */
+	double minimumValue() default Double.NaN;
+
+	/**
+	 * For numeric types, a maximum value, inclusive. Optional.
+	 */
+	double maximumValue() default Double.NaN;
+
+	/**
+	 * Regular expression to validate (String) values against. This is only 
+	 * applied to parameters that are provided as strings. Optional.
+	 */
+	String regexValidation() default "";
+
+	/**
+	 * The probability distribution to use when generating random values for 
+	 * this parameter. Optional. 
+	 * NOT IMPLEMENTED YET.
+	 */
+	ProbDistribution probDistribution() default ProbDistribution.UNIFORM;
+
+	/**
+	 * The standard deviation to use when generating random values for this 
+	 * parameter. Optional. NOT IMPLEMENTED YET.
+	 */
+	double probStdDev() default 1.0;
+
+	/**
+	 * Used to determine the order of parameters when displayed to a user. 
+	 * Optional. If two parameters have the same order value then they will 
+	 * be ordered according to the field name.
+	 */
+	int order() default 0;
+}

--- a/src/org/simbrain/network/gui/dialogs/synapse/AbstractSynapseRulePanel.java
+++ b/src/org/simbrain/network/gui/dialogs/synapse/AbstractSynapseRulePanel.java
@@ -41,10 +41,12 @@ import org.simbrain.network.synapse_update_rules.HebbianCPCARule;
 import org.simbrain.network.synapse_update_rules.HebbianRule;
 import org.simbrain.network.synapse_update_rules.HebbianThresholdRule;
 import org.simbrain.network.synapse_update_rules.OjaRule;
+import org.simbrain.network.synapse_update_rules.PfisterGerstner2006Rule;
 import org.simbrain.network.synapse_update_rules.STDPRule;
 import org.simbrain.network.synapse_update_rules.ShortTermPlasticityRule;
 import org.simbrain.network.synapse_update_rules.StaticSynapseRule;
 import org.simbrain.network.synapse_update_rules.SubtractiveNormalizationRule;
+import org.simbrain.network.synapse_update_rules.TestAnnotatedRule;
 import org.simbrain.util.LabelledItemPanel;
 
 /**
@@ -73,11 +75,15 @@ public abstract class AbstractSynapseRulePanel extends JPanel {
         RULE_MAP.put(new HebbianThresholdRule().getName(),
             new HebbianThresholdRulePanel());
         RULE_MAP.put(new OjaRule().getName(), new OjaRulePanel());
+        RULE_MAP.put(new PfisterGerstner2006Rule().getName(),
+            new SynapseRuleUserParamPanel(new PfisterGerstner2006Rule()));
         //RULE_MAP.put(new ShortTermPlasticityRule().getDescription(),
         //    new ShortTermPlasticityRulePanel());
         RULE_MAP.put(new STDPRule().getName(), new STDPRulePanel());
         RULE_MAP.put(new SubtractiveNormalizationRule().getName(),
             new SubtractiveNormalizationRulePanel());
+        RULE_MAP.put(new TestAnnotatedRule().getName(),
+            new SynapseRuleUserParamPanel(new TestAnnotatedRule()));
     }
 
     /**

--- a/src/org/simbrain/network/gui/dialogs/synapse/SynapseRuleUserParamPanel.java
+++ b/src/org/simbrain/network/gui/dialogs/synapse/SynapseRuleUserParamPanel.java
@@ -1,0 +1,206 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.network.gui.dialogs.synapse;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.swing.JLabel;
+import javax.swing.JToolTip;
+
+import org.simbrain.network.core.Synapse;
+import org.simbrain.network.core.SynapseUpdateRule;
+import org.simbrain.network.gui.Parameter;
+import org.simbrain.network.gui.ParameterWidget;
+import org.simbrain.network.gui.UserParameter;
+
+
+/**
+ * A synapse rule parameter editing panel for synapse update rules that use 
+ * parameter fields annotated with {@link UserParameter}.
+ * Automatically adds fields for all UserParameter-annotated fields.
+ * May be sub-classed to add custom fields or behaviour.
+ * 
+ * @author O. J. Coleman
+ */
+public class SynapseRuleUserParamPanel extends AbstractSynapseRulePanel {
+	/**
+	 * The available parameters, as a map from Parameter to input gui component
+	 */
+	protected Set<ParameterWidget> params;
+	
+	/**
+	 * The  prototype rule.
+	 */
+	protected SynapseUpdateRule prototypeRule;
+	
+	
+	/**
+     * Create a new SynapseRuleUserParamPanel for the given rule.
+     */
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+	public SynapseRuleUserParamPanel(SynapseUpdateRule prototypeRule) {
+    	this();
+    	setRule(prototypeRule);
+    }
+    
+    
+    /**
+     * Create a new SynapseRuleUserParamPanel with no rule set.
+     * {@link #setRule(SynapseUpdateRule)} must be set before other methods are called.
+     * Mostly for internal use. 
+     */
+    public SynapseRuleUserParamPanel() {
+    }
+    
+    
+    public void setRule(SynapseUpdateRule prototypeRule) {
+    	if (this.prototypeRule != null) {
+    		throw new IllegalStateException("Multiple calls to SynapseRuleUserParamPanel.setRule(SynapseUpdateRule) are not allowed.");
+    	}
+    	
+    	this.prototypeRule = prototypeRule;
+    	
+    	params = new TreeSet<>();
+    	for (Parameter param : Parameter.getParameters(prototypeRule.getClass())) {
+    		params.add(new ParameterWidget(param));
+    	}
+    	
+    	// Add parameter widgets after collecting list of params so they're in the right order. 
+    	for (ParameterWidget pw : params) {
+    		JLabel label = new JLabel(pw.parameter.annotation.label());
+    		label.setToolTipText(pw.getToolTipText());
+    		this.addItemLabel(label, pw.component);
+    	}
+    }
+    
+    
+    @Override
+    public SynapseRuleUserParamPanel deepCopy() {
+    	SynapseRuleUserParamPanel copy;
+		
+    	try {
+			copy = this.getClass().getConstructor().newInstance();
+			// If a (sub-class) constructor didn't call SynapseRuleUserParamPanel(SynapseUpdateRule) 
+			if (copy.prototypeRule == null) {
+				copy.setRule(this.prototypeRule);
+			}
+		} catch (InstantiationException | IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException | SecurityException e) {
+			throw new RuntimeException("The class " + this.getClass().getName() + " must declare a constructor accepting no arguments (or override the deepCopy() method).", e);
+		}
+		
+    	// Iterate over both sets of parameters. They should be in the same order, 
+    	// unless something very odd is going on with the loaded classes.
+    	Iterator<ParameterWidget> thisParamsItr = params.iterator();
+    	Iterator<ParameterWidget> copyParamsItr = copy.params.iterator();
+    	while (thisParamsItr.hasNext()) {
+    		ParameterWidget thisPW = thisParamsItr.next();
+    		ParameterWidget copyPW = copyParamsItr.next();
+    		assert (thisPW.equals(copyPW));
+    		copyPW.setWidgetValue(thisPW.getWidgetValue());
+    	}
+	    return copy;
+    }
+    
+
+	@Override
+	public void fillFieldValues(List<SynapseUpdateRule> ruleList) {
+		SynapseUpdateRule refSynapse = ruleList.get(0);
+		
+		for (ParameterWidget pw : params) {
+			// Check to see if the field values are consistent over all given instances.
+			boolean consistent = true;
+			Object refValue = pw.parameter.getFieldValue(refSynapse);
+			for (int i = 1; i < ruleList.size(); i++) {
+			    SynapseUpdateRule rule = ruleList.get(i);
+			    Object ruleValue = pw.parameter.getFieldValue(rule);
+				if ((refValue == null && ruleValue != null) || (refValue != null && !refValue.equals(ruleValue))) {
+					consistent = false;
+					break;
+				}
+			}
+			
+			if (!consistent) {
+				pw.setWidgetValue(null);
+	        } else {
+	        	pw.setWidgetValue(refValue);
+	        }
+		}
+	}
+	
+
+	@Override
+	public void fillDefaultValues() {
+		for (ParameterWidget pw : params) {
+			pw.setWidgetValue(pw.parameter.getDefaultValue());
+	    }
+	}
+
+	@Override
+	public void commitChanges(Synapse synapse) {
+        if (!synapse.getLearningRule().getClass().equals(prototypeRule.getClass())) {
+            synapse.setLearningRule(prototypeRule.deepCopy());
+        }
+        writeValuesToRules(Collections.singletonList(synapse));
+	}
+
+	@Override
+	public void commitChanges(Collection<Synapse> synapses) {
+        if (isReplace()) {
+            for (Synapse s : synapses) {
+            	// Only replace if this is a different rule (otherwise when 
+            	// editing multiple rules with different parameter values which
+            	// have not been set those values will be replaced with the default).
+            	if (!s.getLearningRule().getClass().equals(prototypeRule.getClass())) {
+            		s.setLearningRule(prototypeRule.deepCopy());
+            	}
+            }
+        }
+        writeValuesToRules(synapses);
+	}
+
+	@Override
+	protected void writeValuesToRules(Collection<Synapse> synapses) {
+		for (ParameterWidget pw : params) {
+			Object value = pw.getWidgetValue();
+			
+			// Ignore unspecified values.
+			// If the value isn't null and it's either not a String or not an empty string.
+			if (value != null && (!(value instanceof String) || !((String) value).equals(""))) {
+				for (Synapse s : synapses) {
+					pw.parameter.setFieldValue(s.getLearningRule(), value);
+				}
+			}
+		}
+		// Re-initialise. Allows updating cached values calculated from parameters.
+		for (Synapse s : synapses) {
+			s.getLearningRule().init(s);
+		}
+	}
+	
+	@Override
+	public SynapseUpdateRule getPrototypeRule() {
+		return prototypeRule;
+	}
+}

--- a/src/org/simbrain/network/synapse_update_rules/PfisterGerstner2006Rule.java
+++ b/src/org/simbrain/network/synapse_update_rules/PfisterGerstner2006Rule.java
@@ -1,0 +1,272 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.network.synapse_update_rules;
+
+import org.simbrain.network.core.Synapse;
+import org.simbrain.network.core.SynapseUpdateRule;
+
+
+/**
+ * Implementation of the model described by Pfister, J-P, Gerstner, W: 
+ * Triplets of Spikes in a Model of Spike Timing-Dependent Plasticity. 
+ * J. Neurosci. 26, 9673–9682 (2006).
+ * 
+ * Only works if source and target neurons are spiking neurons.
+ * 
+ * @author Oliver J. Coleman
+ */
+public class PfisterGerstner2006Rule extends SynapseUpdateRule {
+	/**
+	 * Decay rate for r1 trace, as a multiplier.
+	 */
+    protected double tauPlusDecayMult = 1/16.8;
+
+	/**
+	 * Decay rate for r2 trace, as a multiplier.
+	 */
+    protected double tauXDecayMult = 1/1.0;
+
+	/**
+	 * Decay rate for o1 trace, as a multiplier.
+	 */
+    protected double tauNegDecayMult = 1/33.7;
+
+	/**
+	 * Decay rate for o2 trace, as a multiplier.
+	 */
+    protected double tauYDecayMult = 1/48.0;
+
+	/**
+	 * Amplitude of the weight change for a pre-post spike pair.
+	 */
+    protected double a2N = 0.003;
+
+	/**
+	 * Amplitude of the weight change for a post-pre spike pair.
+	 */
+    protected double a2P = 0.0046;
+
+	/**
+	 * Amplitude of the triplet term for potentiation.
+	 */
+    protected double a3N = 0;
+
+	/**
+	 * Amplitude of the triplet term for depression.
+	 */
+    protected double a3P = 0.0091;
+    
+    
+    // Spike traces.
+	private double r1, r2, o1, o2;
+
+	
+    @Override
+    public void init(Synapse synapse) {
+    }
+
+    
+    @Override
+    public String getName() {
+        return "Pfister and Gerstner, 2006";
+    }
+
+    
+    @Override
+    public SynapseUpdateRule deepCopy() {
+        PfisterGerstner2006Rule duplicateSynapse = new PfisterGerstner2006Rule();
+        duplicateSynapse.tauPlusDecayMult = this.tauPlusDecayMult;
+        duplicateSynapse.tauXDecayMult = this.tauXDecayMult;
+        duplicateSynapse.tauNegDecayMult = this.tauNegDecayMult;
+        duplicateSynapse.tauYDecayMult = this.tauYDecayMult;
+        duplicateSynapse.a2N = this.a2N;
+        duplicateSynapse.a2P = this.a2P;
+        duplicateSynapse.a3N = this.a3N;
+        duplicateSynapse.a3P = this.a3P;
+        return duplicateSynapse;
+    }
+    
+    
+    @Override
+    public void update(Synapse synapse) {
+    	// Time step in ms.
+    	final double timeStep = synapse.getNetwork().getTimeStep();
+    	final boolean preSpiked = synapse.getSource().isSpike();
+    	final boolean postSpiked = synapse.getTarget().isSpike();
+    		
+		// Need current values for these traces for strength update equations below.
+		final double r2p = r2;
+		final double o2p = o2;
+
+		// Update trace values.
+		if (preSpiked) {
+			r1 = 1;
+			r2 = 1;
+		}
+		else {
+			r1 -= r1 * tauPlusDecayMult * timeStep;
+			r2 -= r2 * tauXDecayMult * timeStep;
+		}
+		if (postSpiked) {
+			o1 = 1;
+			o2 = 1;
+		}
+		else {
+			o1 -= o1 * tauNegDecayMult * timeStep;
+			o2 -= o2 * tauYDecayMult * timeStep;
+		}
+		
+		// Update efficacy if a pre or post spike occurred.
+		if (preSpiked) {
+			synapse.setStrength(synapse.getStrength() - o1 * (a2N + a3N * r2p));
+		}
+		
+		if (postSpiked) {
+			synapse.setStrength(synapse.getStrength() + r1 * (a2P + a3P * o2p));
+		}
+    }
+
+
+	/**
+	 * @return Decay rate for r1 trace.
+	 */
+	public double getTauPlusDecay() {
+		return 1 / tauPlusDecayMult;
+	}
+
+
+	/**
+	 * @param tauPlusDecay Decay rate for r1 trace.
+	 */
+	public void setTauPlusDecay(double tauPlusDecay) {
+		this.tauPlusDecayMult = 1 / tauPlusDecay;
+	}
+
+
+	/**
+	 * @return Decay rate for r2 trace.
+	 */
+	public double getTauXDecay() {
+		return 1 / tauXDecayMult;
+	}
+
+
+	/**
+	 * @param tauXDecay Decay rate for r2 trace.
+	 */
+	public void setTauXDecay(double tauXDecay) {
+		this.tauXDecayMult = 1 / tauXDecay;
+	}
+
+
+	/**
+	 * @return Decay rate for o1 trace.
+	 */
+	public double getTauNegDecay() {
+		return 1 / tauNegDecayMult;
+	}
+
+
+	/**
+	 * @param tauNegDecay Decay rate for o1 trace.
+	 */
+	public void setTauNegDecay(double tauNegDecay) {
+		this.tauNegDecayMult = 1 / tauNegDecay;
+	}
+
+
+	/**
+	 * @return Decay rate for o2 trace.
+	 */
+	public double getTauYDecay() {
+		return 1 / tauYDecayMult;
+	}
+
+
+	/**
+	 * @param tauYDecay Decay rate for o2 trace.
+	 */
+	public void setTauYDecay(double tauYDecay) {
+		this.tauYDecayMult = 1 / tauYDecay;
+	}
+
+
+	/**
+	 * @return Amplitude of the weight change for a pre-post spike pair.
+	 */
+	public double getA2P() {
+		return a2P;
+	}
+
+
+	/**
+	 * @param a2p Amplitude of the weight change for a pre-post spike pair.
+	 */
+	public void setA2P(double a2p) {
+		a2P = a2p;
+	}
+
+
+	/**
+	 * @return Amplitude of the weight change for a post-pre spike pair.
+	 */
+	public double getA2N() {
+		return a2N;
+	}
+
+
+	/**
+	 * @param Amplitude of the weight change for a post-pre spike pair.
+	 */
+	public void setA2N(double a2n) {
+		a2N = a2n;
+	}
+
+
+	/**
+	 * @return Amplitude of the triplet term for potentiation.
+	 */
+	public double getA3P() {
+		return a3P;
+	}
+
+
+	/**
+	 * @param Amplitude of the triplet term for potentiation.
+	 */
+	public void setA3P(double a3p) {
+		a3P = a3p;
+	}
+
+
+    /**
+	 * @return Amplitude of the triplet term for depression.
+	 */
+	public double getA3N() {
+		return a3N;
+	}
+
+
+	/**
+	 * @param a3n Amplitude of the triplet term for depression.
+	 */
+	public void setA3N(double a3n) {
+		a3N = a3n;
+	}
+}

--- a/src/org/simbrain/network/synapse_update_rules/TestAnnotatedRule.java
+++ b/src/org/simbrain/network/synapse_update_rules/TestAnnotatedRule.java
@@ -1,0 +1,66 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.network.synapse_update_rules;
+
+import org.simbrain.network.core.Synapse;
+import org.simbrain.network.core.SynapseUpdateRule;
+import org.simbrain.network.gui.UserParameter;
+
+
+/**
+ * Test annotated param. 
+ * Extends PfisterGerstner2006Rule which defines floating params. 
+ * This also tests handling params defined in super-classes.
+ * 
+ * @author Oliver J. Coleman
+ */
+public class TestAnnotatedRule extends PfisterGerstner2006Rule {
+	@UserParameter(label="test string", description="Test string parameter.", order=-1)
+    protected String ts;
+	
+	@UserParameter(label="test bool", description="Test boolean parameter.", order=-1, defaultValue="true")
+    protected boolean tb;
+	
+	@UserParameter(label="test int def", description="Test int parameter with default.", order=-1, defaultValue="2")
+    protected int ti;
+	
+	@UserParameter(label="test int min", description="Test int parameter with minimum.", order=-1, minimumValue=1)
+    protected int timin;
+
+	@UserParameter(label="test int max", description="Test int parameter with maximum.", order=-1, maximumValue=-50)
+    protected int timax;
+	
+	@UserParameter(label="test int min max", description="Test int parameter with min and max.", order=-1, minimumValue=-10, maximumValue=200)
+    protected int timinmax;
+	
+	@Override
+	public String getName() {
+		return "TestAnnotatedRule";
+	}
+	
+	
+    @Override
+    public SynapseUpdateRule deepCopy() {
+    	try {
+			return (PfisterGerstner2006Rule) this.clone();
+		} catch (CloneNotSupportedException e) {
+			throw new RuntimeException(e);
+		}
+    }
+}

--- a/src/org/simbrain/util/widgets/JNumberSpinnerWithNull.java
+++ b/src/org/simbrain/util/widgets/JNumberSpinnerWithNull.java
@@ -1,0 +1,150 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.util.widgets;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.text.ParseException;
+
+import javax.swing.JComponent;
+import javax.swing.JFormattedTextField;
+import javax.swing.JSpinner;
+import javax.swing.JTextField;
+import javax.swing.SpinnerModel;
+import javax.swing.SpinnerNumberModel;
+import javax.swing.text.DefaultFormatterFactory;
+import javax.swing.text.NumberFormatter;
+
+/**
+ * A JSpinner supporting null (numeric) values, represented as "...".
+ * 
+ * @see SpinnerNumberModelWithNull
+ * 
+ * @author O. J. Coleman
+ */
+public class JNumberSpinnerWithNull extends JSpinner {
+	public  JNumberSpinnerWithNull(SpinnerNumberModelWithNull model) {
+		super(model);
+	}
+	
+	
+	protected JComponent createEditor(SpinnerModel model) {
+		if (model instanceof SpinnerNumberModelWithNull) {
+			return new NumberEditorWithNull(this);
+		}
+		return super.createEditor(model);
+	}
+	
+	
+    
+	public static class NumberEditorWithNull extends JSpinner.NumberEditor {
+		public NumberEditorWithNull(JNumberSpinnerWithNull spinner) {
+			this(spinner, (DecimalFormat) NumberFormat.getNumberInstance(spinner.getLocale()));
+		}
+
+		public NumberEditorWithNull(JNumberSpinnerWithNull spinner, String decimalFormatPattern) {
+			this(spinner, new DecimalFormat(decimalFormatPattern));
+		}
+		
+		
+        public NumberEditorWithNull(JSpinner spinner, DecimalFormat format) {
+            super(spinner);
+            if (!(spinner.getModel() instanceof SpinnerNumberModel)) {
+                throw new IllegalArgumentException(
+                          "model not a SpinnerNumberModel");
+            }
+
+            SpinnerNumberModel model = (SpinnerNumberModel) spinner.getModel();
+            NumberFormatter formatterEditor = new NumberEditorFormatter(model, format);
+            NumberFormatter formatterDisplay = new NumberEditorFormatterWithNull(model, format);
+            DefaultFormatterFactory factory = new DefaultFormatterFactory(formatterEditor, formatterDisplay);
+            JFormattedTextField ftf = getTextField();
+            ftf.setEditable(true);
+            ftf.setFormatterFactory(factory);
+            ftf.setHorizontalAlignment(JTextField.RIGHT);
+
+            /* TBD - initializing the column width of the text field
+             * is imprecise and doing it here is tricky because
+             * the developer may configure the formatter later.
+             */
+            try {
+                String maxString = formatterEditor.valueToString(model.getMinimum());
+                String minString = formatterEditor.valueToString(model.getMaximum());
+                ftf.setColumns(Math.max(maxString.length(),
+                                        minString.length()));
+            }
+            catch (ParseException e) {
+                // TBD should throw a chained error here
+            }
+
+        }
+    }
+	
+	
+	
+	public static class NumberEditorFormatter extends NumberFormatter {
+        protected final SpinnerNumberModel model;
+
+        public NumberEditorFormatter(SpinnerNumberModel model, NumberFormat format) {
+            super(format);
+            this.model = model;
+            setValueClass(model.getValue().getClass());
+        }
+
+        public void setMinimum(Comparable min) {
+            model.setMinimum(min);
+        }
+
+        public Comparable getMinimum() {
+            return  model.getMinimum();
+        }
+
+        public void setMaximum(Comparable max) {
+            model.setMaximum(max);
+        }
+
+        public Comparable getMaximum() {
+            return model.getMaximum();
+        }
+    }
+	
+	
+
+	public static class NumberEditorFormatterWithNull extends NumberEditorFormatter {
+        NumberEditorFormatterWithNull(SpinnerNumberModel model, NumberFormat format) {
+            super(model, format);
+        }
+
+		@Override
+		public Object stringToValue(String text) throws ParseException {
+			if (text == null || text.equals("") || text.equals("...")) {
+				return null;
+			}
+			return super.stringToValue(text);
+		}
+
+		@Override
+		public String valueToString(Object value) throws ParseException {
+			if (value == null) {
+				return "...";
+			}
+			return super.valueToString(value);
+		}
+    }
+}

--- a/src/org/simbrain/util/widgets/SpinnerNumberModelWithNull.java
+++ b/src/org/simbrain/util/widgets/SpinnerNumberModelWithNull.java
@@ -1,0 +1,360 @@
+/*
+ * Part of Simbrain--a java-based neural network kit
+ * Copyright (C) 2005,2007 The Authors.  See http://www.simbrain.net/credits
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+package org.simbrain.util.widgets;
+
+import javax.swing.SpinnerNumberModel;
+
+
+/**
+ * A SpinnerNumberModel that allows a null state. 
+ * When the edited objects return different states the field is shown as empty.
+ *
+ * @see JNumberSpinnerWithNull
+ *
+ * @author O. J. Coleman
+ */
+public class SpinnerNumberModelWithNull extends SpinnerNumberModel {
+	private Number stepSize, value;
+    private Comparable minimum, maximum;
+
+	
+    /**
+     * Constructs a <code>SpinnerModel</code> that represents
+     * a closed sequence of
+     * numbers from <code>minimum</code> to <code>maximum</code>.  The
+     * <code>nextValue</code> and <code>previousValue</code> methods
+     * compute elements of the sequence by adding or subtracting
+     * <code>stepSize</code> respectively.  All of the parameters
+     * must be mutually <code>Comparable</code>, <code>value</code>
+     * and <code>stepSize</code> must be instances of <code>Integer</code>
+     * <code>Long</code>, <code>Float</code>, or <code>Double</code>.
+     * <p>
+     * The <code>minimum</code> and <code>maximum</code> parameters
+     * can be <code>null</code> to indicate that the range doesn't
+     * have an upper or lower bound.
+     * If <code>value</code> or <code>stepSize</code> is <code>null</code>,
+     * or if both <code>minimum</code> and <code>maximum</code>
+     * are specified and <code>minimum &gt; maximum</code> then an
+     * <code>IllegalArgumentException</code> is thrown.
+     * Similarly if <code>(minimum &lt;= value &lt;= maximum</code>) is false,
+     * an <code>IllegalArgumentException</code> is thrown.
+     *
+     * @param value the current (non <code>null</code>) value of the model
+     * @param minimum the first number in the sequence or <code>null</code>
+     * @param maximum the last number in the sequence or <code>null</code>
+     * @param stepSize the difference between elements of the sequence
+     *
+     * @throws IllegalArgumentException if stepSize or value is
+     *     <code>null</code> or if the following expression is false:
+     *     <code>minimum &lt;= value &lt;= maximum</code>
+     */
+    public SpinnerNumberModelWithNull(Number value, Comparable minimum, Comparable maximum, Number stepSize) {
+        if (stepSize == null) {
+            throw new IllegalArgumentException("stepSize must be non-null");
+        }
+        this.value = value;
+        this.minimum = minimum;
+        this.maximum = maximum;
+        this.stepSize = stepSize;
+    }
+    
+    
+    /**
+     * Changes the lower bound for numbers in this sequence.
+     * If <code>minimum</code> is <code>null</code>,
+     * then there is no lower bound.  No bounds checking is done here;
+     * the new <code>minimum</code> value may invalidate the
+     * <code>(minimum &lt;= value &lt;= maximum)</code>
+     * invariant enforced by the constructors.  This is to simplify updating
+     * the model, naturally one should ensure that the invariant is true
+     * before calling the <code>getNextValue</code>,
+     * <code>getPreviousValue</code>, or <code>setValue</code> methods.
+     * <p>
+     * Typically this property is a <code>Number</code> of the same type
+     * as the <code>value</code> however it's possible to use any
+     * <code>Comparable</code> with a <code>compareTo</code>
+     * method for a <code>Number</code> with the same type as the value.
+     * For example if value was a <code>Long</code>,
+     * <code>minimum</code> might be a Date subclass defined like this:
+     * <pre>
+     * MyDate extends Date {  // Date already implements Comparable
+     *     public int compareTo(Long o) {
+     *         long t = getTime();
+     *         return (t &lt; o.longValue() ? -1 : (t == o.longValue() ? 0 : 1));
+     *     }
+     * }
+     * </pre>
+     * <p>
+     * This method fires a <code>ChangeEvent</code>
+     * if the <code>minimum</code> has changed.
+     *
+     * @param minimum a <code>Comparable</code> that has a
+     *     <code>compareTo</code> method for <code>Number</code>s with
+     *     the same type as <code>value</code>
+     * @see #getMinimum
+     * @see #setMaximum
+     * @see SpinnerModel#addChangeListener
+     */
+    public void setMinimum(Comparable minimum) {
+        if ((minimum == null) ? (this.minimum != null) : !minimum.equals(this.minimum)) {
+            this.minimum = minimum;
+            fireStateChanged();
+        }
+    }
+
+
+    /**
+     * Returns the first number in this sequence.
+     *
+     * @return the value of the <code>minimum</code> property
+     * @see #setMinimum
+     */
+    public Comparable getMinimum() {
+        return minimum;
+    }
+
+
+    /**
+     * Changes the upper bound for numbers in this sequence.
+     * If <code>maximum</code> is <code>null</code>, then there
+     * is no upper bound.  No bounds checking is done here; the new
+     * <code>maximum</code> value may invalidate the
+     * <code>(minimum &lt;= value &lt; maximum)</code>
+     * invariant enforced by the constructors.  This is to simplify updating
+     * the model, naturally one should ensure that the invariant is true
+     * before calling the <code>next</code>, <code>previous</code>,
+     * or <code>setValue</code> methods.
+     * <p>
+     * Typically this property is a <code>Number</code> of the same type
+     * as the <code>value</code> however it's possible to use any
+     * <code>Comparable</code> with a <code>compareTo</code>
+     * method for a <code>Number</code> with the same type as the value.
+     * See <a href="#setMinimum(java.lang.Comparable)">
+     * <code>setMinimum</code></a> for an example.
+     * <p>
+     * This method fires a <code>ChangeEvent</code> if the
+     * <code>maximum</code> has changed.
+     *
+     * @param maximum a <code>Comparable</code> that has a
+     *     <code>compareTo</code> method for <code>Number</code>s with
+     *     the same type as <code>value</code>
+     * @see #getMaximum
+     * @see #setMinimum
+     * @see SpinnerModel#addChangeListener
+     */
+    public void setMaximum(Comparable maximum) {
+        if ((maximum == null) ? (this.maximum != null) : !maximum.equals(this.maximum)) {
+            this.maximum = maximum;
+            fireStateChanged();
+        }
+    }
+
+
+    /**
+     * Returns the last number in the sequence.
+     *
+     * @return the value of the <code>maximum</code> property
+     * @see #setMaximum
+     */
+    public Comparable getMaximum() {
+        return maximum;
+    }
+
+
+    /**
+     * Changes the size of the value change computed by the
+     * <code>getNextValue</code> and <code>getPreviousValue</code>
+     * methods.  An <code>IllegalArgumentException</code>
+     * is thrown if <code>stepSize</code> is <code>null</code>.
+     * <p>
+     * This method fires a <code>ChangeEvent</code> if the
+     * <code>stepSize</code> has changed.
+     *
+     * @param stepSize the size of the value change computed by the
+     *     <code>getNextValue</code> and <code>getPreviousValue</code> methods
+     * @see #getNextValue
+     * @see #getPreviousValue
+     * @see #getStepSize
+     * @see SpinnerModel#addChangeListener
+     */
+    public void setStepSize(Number stepSize) {
+        if (stepSize == null) {
+            throw new IllegalArgumentException("null stepSize");
+        }
+        if (!stepSize.equals(this.stepSize)) {
+            this.stepSize = stepSize;
+            fireStateChanged();
+        }
+    }
+
+
+    /**
+     * Returns the size of the value change computed by the
+     * <code>getNextValue</code>
+     * and <code>getPreviousValue</code> methods.
+     *
+     * @return the value of the <code>stepSize</code> property
+     * @see #setStepSize
+     */
+    public Number getStepSize() {
+        return stepSize;
+    }
+
+
+    private Number incrValue(int dir)
+    {
+    	if (value == null) {
+    		return null;
+    	}
+    	
+        Number newValue;
+        if ((stepSize instanceof Float) || (stepSize instanceof Double)) {
+            double v = value.doubleValue() + (stepSize.doubleValue() * (double)dir);
+            if (value instanceof Double) {
+                newValue = new Double(v);
+            }
+            else {
+                newValue = new Float(v);
+            }
+        }
+        else {
+            long v = value.longValue() + (stepSize.longValue() * (long)dir);
+
+            if (value instanceof Long) {
+                newValue = Long.valueOf(v);
+            }
+            else if (value instanceof Integer) {
+                newValue = Integer.valueOf((int)v);
+            }
+            else if (value instanceof Short) {
+                newValue = Short.valueOf((short)v);
+            }
+            else {
+                newValue = Byte.valueOf((byte)v);
+            }
+        }
+
+        if ((maximum != null) && (maximum.compareTo(newValue) < 0)) {
+            return null;
+        }
+        if ((minimum != null) && (minimum.compareTo(newValue) > 0)) {
+            return null;
+        }
+        else {
+            return newValue;
+        }
+    }
+
+
+    /**
+     * Returns the next number in the sequence.
+     *
+     * @return <code>value + stepSize</code> or <code>null</code> if the sum
+     *     exceeds <code>maximum</code>.
+     *
+     * @see SpinnerModel#getNextValue
+     * @see #getPreviousValue
+     * @see #setStepSize
+     */
+    public Object getNextValue() {
+        return incrValue(+1);
+    }
+
+
+    /**
+     * Returns the previous number in the sequence.
+     *
+     * @return <code>value - stepSize</code>, or
+     *     <code>null</code> if the sum is less
+     *     than <code>minimum</code>.
+     *
+     * @see SpinnerModel#getPreviousValue
+     * @see #getNextValue
+     * @see #setStepSize
+     */
+    public Object getPreviousValue() {
+        return incrValue(-1);
+    }
+
+
+    /**
+     * Returns the value of the current element of the sequence,
+     * or null if no value is set.
+     *
+     * @return the value property, or null if no value is set.
+     * @see #setValue
+     */
+    public Number getNumber() {
+        return value;
+    }
+
+
+    /**
+     * Returns the value of the current element of the sequence,
+     * or null if no value is set.
+     *
+     * @return the value property, or null if no value is set.
+     * @see #setValue
+     * @see #getNumber
+     */
+    public Object getValue() {
+        return value;
+    }
+
+
+    /**
+     * Sets the current value for this sequence.
+     * <p>
+     * This method fires a <code>ChangeEvent</code> if the value has changed.
+     *
+     * @param value the current <code>Number</code>
+     *         for this sequence, or null for no value.
+     * @throws IllegalArgumentException if <code>value</code> is
+     * not null and is not a <code>Number</code>
+     * @see #getNumber
+     * @see #getValue
+     * @see SpinnerModel#addChangeListener
+     */
+    public void setValue(Object value) {
+    	if (value == null) {
+    		if (this.value != null) {
+                this.value = null;
+                fireStateChanged();
+            }
+    	}
+    	else {
+	        if (!(value instanceof Number)) {
+	            throw new IllegalArgumentException("illegal value");
+	        }
+	        if (!value.equals(this.value)) {
+	        	Number newValue = (Number)value;
+	            
+	            if ((maximum != null) && (maximum.compareTo(newValue) < 0)) {
+	            	newValue = (Number) maximum;
+	            }
+	            else if ((minimum != null) && (minimum.compareTo(newValue) > 0)) {
+	            	newValue = (Number) minimum;
+	            }
+	            
+	            this.value = newValue;
+	            fireStateChanged();
+	        }
+    	}
+    }
+}


### PR DESCRIPTION
A first bash at implementing this for _SynapseUpdateRules_.

Adds a new class, _SynapseRuleUserParamPanel_, that implements _AbstractSynapseRulePanel_ and can be passed a _SynapseUpdateRule_ instance that contains fields annotated with the new class _UserParameter_. It automatically creates the relevant UI fields.

This PR also adds the (annotated) _PfisterGerstner2006Rule_ (currently untested), and a test rule _TestAnnotatedRule_ that should be removed before merging.

The UserParameter annotation class defines settings for generating random numbers for a parameter but this has not yet been implemented.

Classes added are:
* **org.simbrain.network.gui.UserParameter** annotation class for annotating user-editable fields.
* **org.simbrain.network.gui.dialogs.synapse.SynapseRuleUserParamPanel** (see above).
* **org.simbrain.network.gui.Parameter** manages working with class fields annotated with _UserParameter_.
* **org.simbrain.network.gui.ParameterWidget** acts as a bridge between _Parameter_ instances and associated UI widgets.
* **org.simbrain.util.widgets.JNumberSpinnerWithNull** a _JSpinner_ for numbers that supports null values (displays "..." for null values).
* **org.simbrain.util.widgets.SpinnerNumberModelWithNull** spinner model for _JNumberSpinnerWithNull_.
