### PR TITLE
Fix for TextWorld BLAS error

### DIFF
--- a/src/main/kotlin/org/simbrain/util/TextUtilities.kt
+++ b/src/main/kotlin/org/simbrain/util/TextUtilities.kt
@@ -168,7 +168,7 @@ fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, skipGram:
     if (usePPMI) {
         return Pair(tokens, manualPPMI(cooccurrenceSmileMatrix, true))
     }
-    return Pair(tokens, cooccurrenceSmileMatrix)
+    return Pair(tokens, cooccurrenceSmileMatrix.replaceNaN(0.0))
 }
 
 /**

--- a/src/main/kotlin/org/simbrain/world/textworld/TextWorldActions.kt
+++ b/src/main/kotlin/org/simbrain/world/textworld/TextWorldActions.kt
@@ -88,7 +88,7 @@ object TextWorldActions {
             override fun actionPerformed(arg0: ActionEvent) {
                 // TODO: Find a way to show the tokens as rowHeaders
                 // Find a way to make it immutable
-                val model = createFromDoubleArray(world!!.tokenVectorMap.tokenVectorMatrix.toArray())
+                val model = createFromDoubleArray(world!!.tokenVectorMap.tokenVectorMatrix.replaceNaN(0.0).toArray())
                 model.insertColumn(0, "Token", Column.DataType.StringType)
                 world.tokenVectorMap.tokensMap.keys.forEachIndexed {
                     rowIndex, token -> model.setValueAt(token, rowIndex, 0 )

--- a/src/test/kotlin/org/simbrain/util/TextUtilsTest.kt
+++ b/src/test/kotlin/org/simbrain/util/TextUtilsTest.kt
@@ -3,6 +3,7 @@ package org.simbrain.util
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.simbrain.custom_sims.getResource
 import smile.math.matrix.Matrix
 
 class TextUtilsTest {
@@ -18,6 +19,7 @@ class TextUtilsTest {
 
     val windowSizeText = "Albert ran into the store, while Jean walked into the store. Jean packed all the books, after Albert read all the books."
 
+    val mlkText = "And so even though we face the difficulties of today and tomorrow, I still have a dream. It is a dream deeply rooted in the American dream. I have a dream that one day this nation will rise up and live out the true meaning of its creed: We hold these truths to be self-evident, that all men are created equal. I have a dream that one day on the red hills of Georgia, the sons of former slaves and the sons of former slave owners will be able to sit down together at the table of brotherhood. I have a dream that one day even the state of Mississippi, a state sweltering with the heat of injustice, sweltering with the heat of oppression, will be transformed into an oasis of freedom and justice. I have a dream that my four little children will one day live in a nation where they will not be judged by the color of their skin but by the content of their character. I have a dream today! I have a dream that one day, down in Alabama, with its vicious racists, with its governor having his lips dripping with the words of interposition and nullification, one day right there in Alabama little black boys and black girls will be able to join hands with little white boys and white girls as sisters and brothers. I have a dream today! I have a dream that one day every valley shall be exalted, and every hill and mountain shall be made low, the rough places will be made plain, and the crooked places will be made straight; and the glory of the Lord shall be revealed and all flesh shall see it together. This is our hope, and this is the faith that I go back to the South with. With this faith, we will be able to hew out of the mountain of despair a stone of hope. With this faith, we will be able to transform the jangling discords of our nation into a beautiful symphony of brotherhood. With this faith, we will be able to work together, to pray together, to struggle together, to go to jail together, to stand up for freedom together, knowing that we will be free one day. And this will be the day, this will be the day when all of God s children will be able to sing with new meaning: My country  tis of thee, sweet land of liberty, of thee I sing. Land where my fathers died, land of the Pilgrim s pride, From every mountainside, let freedom ring! And if America is to be a great nation, this must become true. And so let freedom ring from the prodigious hilltops of New Hampshire. Let freedom ring from the mighty mountains of New York. Let freedom ring from the heightening Alleghenies of Pennsylvania. Let freedom ring from the snow-capped Rockies of Colorado. Let freedom ring from the curvaceous slopes of California. But not only that: Let freedom ring from Stone Mountain of Georgia. Let freedom ring from Lookout Mountain of Tennessee. Let freedom ring from every hill and molehill of Mississippi. From every mountainside, let freedom ring. And when this happens, when we allow freedom ring, when we let it ring from every village and every hamlet, from every state and every city, we will be able to speed up that day when all of God s children, black men and white men, Jews and Gentiles, Protestants and Catholics, will be able to join hands and sing in the words of the old Negro spiritual: Free at last! Free at last! Thank God Almighty, we are free at last!"
     @Test
     fun `test sentence parsing`() {
         val sentences =  simpleText.tokenizeSentencesFromDoc()
@@ -126,6 +128,18 @@ class TextUtilsTest {
         val vectorB = wordEmbeddingQuery("dog",tokens,cooccurrenceMatrix)
         val vectorC = wordEmbeddingQuery("table",tokens,cooccurrenceMatrix)
         assertTrue(embeddingSimilarity(vectorA, vectorB) > embeddingSimilarity(vectorB, vectorC) )
+    }
+
+    @Test
+    fun `no NaN values in co-occurrence matrix`() {
+        val result = generateCooccurrenceMatrix(mlkText, 2, true)
+        val coocMatrix = result.second
+        val tokens = result.first
+        for (index in 0..tokens.size){
+            // println(coocMatrix[index,0].toString())
+            // println(coocMatrix.row(index).toString())
+            if (coocMatrix[index,0].isNaN()) println(index) // Only checking first value since NaNs occur as the whole row/column
+        }
     }
 
 }


### PR DESCRIPTION
Initial fix for the TextWorld BLAS error that was related to NaN values in the tokenVectorMatrix (line 91 in TextWorldActions).