### PR TITLE
RenameSuggestion

### DIFF
--- a/src/main/java/org/simbrain/network/core/Synapse.java
+++ b/src/main/java/org/simbrain/network/core/Synapse.java
@@ -385,8 +385,8 @@ public class Synapse extends NetworkModel implements EditableObject, AttributeCo
 
         // Handle delays
         if (delay != 0) {
-            dlyVal = dequeu();
-            enqueu(psr);
+            dlyVal = dequeue();
+            enqueue(psr);
             psr = dlyVal;
         }
     }
@@ -650,7 +650,7 @@ public class Synapse extends NetworkModel implements EditableObject, AttributeCo
     /**
      * @return the deque.
      */
-    private double dequeu() {
+    private double dequeue() {
         if (dlyPtr == delay) {
             dlyPtr = 0;
         }
@@ -662,7 +662,7 @@ public class Synapse extends NetworkModel implements EditableObject, AttributeCo
      *
      * @param val Value to enqueu
      */
-    private void enqueu(final double val) {
+    private void enqueue(final double val) {
         if (dlyPtr == 0) {
             delayManager[delay - 1] = val;
         } else {


### PR DESCRIPTION
### Renaming Suggestion of Method Names to Make Them More Descriptive
---
**Description**
---

We have developed a tool (**NameSpotter**) for identifying non-descriptive method names, and using this tool we find a non-descriptive method name in your repository:
```java
/* Non-descriptive Method Name in src/main/java/org/simbrain/network/core/Synapse.java */
    private void enqueu(final double val) {
        if (dlyPtr == 0) {
            delayManager[delay - 1] = val;
        } else {
            delayManager[dlyPtr - 1] = val;
        }
    }
	
	   private double dequeu() {
        if (dlyPtr == delay) {
            dlyPtr = 0;
        }
        return delayManager[dlyPtr++];
    }


```
We considered "enqueu" and "dequeu" as non-descriptive because they contain a typo (i.e., queu should be queue). In src/main/java/org/simbrain/world/threedworld/engine/ThreeDEngine.java, there are another two methods named "enqueue", which may lead to misunderstanding between "enqueu" and "enqueue".
We have corrected it and submitted a pull request.

Do you agree with the judgment? 

- If not, could you please leave your valuable opinion?

- If you do agree, the relevant modification has been submitted as a PR, and thanks for your precious time to consider it.