### PR TITLE
Updated textworld parameters

### DIFF
--- a/src/main/kotlin/org/simbrain/util/TextUtilities.kt
+++ b/src/main/kotlin/org/simbrain/util/TextUtilities.kt
@@ -110,17 +110,17 @@ fun manualPPMI(cocMatrix: Matrix, positive: Boolean = true): Matrix {
 /**
  * Generates co-occurrence matrix from a provided [docString].
  *
- * Example: if [windowSize] is 2 and [skipGram] is true, then the context for "dog" in "the quick dog ran fastly"
- * is ["the", "quick", "ran", "fastly"].  If [windowSize] 2 and [skipGram] false, then the context for "dog"
+ * Example: if [windowSize] is 2 and [bidirectional] is true, then the context for "dog" in "the quick [dog] ran fastly"
+ * is ["the", "quick", "ran", "fastly"].  If [windowSize] 2 and [bidirectional] false, then the context for "dog"
  * is ["the", "quick"].
  *
  * @param windowSize specifies how many words should be included in a context.
- * @param skipGram  if true, window includes this many tokens before AND after; if false the window only includes
+ * @param bidirectional  if true, window includes this many tokens before AND after; if false the window only includes
  * previous tokens.
  * @return a symmetrical co-occurrence matrix with as many rows and columns as there are unique tokens in [docString].
  *
  */
-fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, skipGram: Boolean = false , usePPMI: Boolean = true):
+fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, bidirectional: Boolean = false, usePPMI: Boolean = true):
         Pair<List<String>, Matrix> {
     // println(docString)
     val convertedDocString = docString.removeSpecialCharacters()
@@ -151,7 +151,7 @@ fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, skipGram:
             val currentToken = tokenizedSentence[sentenceIndex] // Current iterated token
 
             val contextLowerLimit = sentenceIndex - windowSize
-            val contextUpperLimit = if (skipGram) (sentenceIndex + windowSize) else (sentenceIndex)
+            val contextUpperLimit = if (bidirectional) (sentenceIndex + windowSize) else (sentenceIndex)
 
             for (contextIndex in contextLowerLimit..contextUpperLimit) {
                 if (contextIndex in 0..maxIndex && contextIndex != sentenceIndex) {

--- a/src/main/kotlin/org/simbrain/util/TextUtilities.kt
+++ b/src/main/kotlin/org/simbrain/util/TextUtilities.kt
@@ -58,6 +58,17 @@ fun removeStopWords(words: List<String>) : List<String> {
     return filteredTargets
 }
 
+fun removeStopWordsFromMatrix(cocMatrix: Matrix, tokens: List<String>) : Matrix {
+    val targets = removeStopWords(tokens)
+    var approvedIndeces = intArrayOf()
+    for (token in tokens){
+        if (targets.contains(token)) approvedIndeces += intArrayOf(tokens.indexOf(token))
+    }
+
+    val cooc2 = cocMatrix.rows(*approvedIndeces)
+    return cooc2
+}
+
 
 // After writing, found out that SimBrain already has an outerProduct function.
 fun outerProduct(vectorU: DoubleArray, vectorV: DoubleArray): Matrix {
@@ -120,7 +131,7 @@ fun manualPPMI(cocMatrix: Matrix, positive: Boolean = true): Matrix {
  * @return a symmetrical co-occurrence matrix with as many rows and columns as there are unique tokens in [docString].
  *
  */
-fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, bidirectional: Boolean = false, usePPMI: Boolean = true):
+fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, bidirectional: Boolean = false, usePPMI: Boolean = true, removeStopwords: Boolean = false):
         Pair<List<String>, Matrix> {
     // println(docString)
     val convertedDocString = docString.removeSpecialCharacters()
@@ -137,7 +148,7 @@ fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, bidirecti
 
     // Set up matrix
     val matrixSize = tokens.size
-    val cooccurrenceSmileMatrix = Matrix(matrixSize, matrixSize)
+    var cooccurrenceSmileMatrix = Matrix(matrixSize, matrixSize)
 
     // cooccurrenceMatrix[0][1] = 2 // cooccurrenceMatrix[target][context]
 
@@ -168,6 +179,11 @@ fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, bidirecti
 
         }
     }
+
+    if (removeStopwords){
+        cooccurrenceSmileMatrix = removeStopWordsFromMatrix(cooccurrenceSmileMatrix, tokens)
+    }
+
     if (usePPMI) {
         return Pair(tokens, manualPPMI(cooccurrenceSmileMatrix, true).replaceNaN(0.0))
     }
@@ -179,7 +195,7 @@ fun generateCooccurrenceMatrix(docString: String, windowSize: Int = 2, bidirecti
  */
 fun wordEmbeddingQuery(targetWord: String, tokens: List<String>, cooccurrenceMatrix: Matrix): DoubleArray {
     val targetWordIndex = tokens.indexOf(targetWord.lowercase())
-    return cooccurrenceMatrix.col(targetWordIndex)
+    return cooccurrenceMatrix.row(targetWordIndex)
 }
 
 /**

--- a/src/main/kotlin/org/simbrain/world/textworld/TextWorld.kt
+++ b/src/main/kotlin/org/simbrain/world/textworld/TextWorld.kt
@@ -60,8 +60,8 @@ class TextWorld : AttributeContainer, EditableObject {
     @UserParameter(label = "Window size", minimumValue =  1.0, order = 20 )
     var windowSize = 5
 
-    @UserParameter(label = "SkipGram", order = 30 )
-    var skipGram = true
+    @UserParameter(label = "Bidirectional", order = 30 )
+    var bidirectional = true
 
     @UserParameter(label = "Use PPMI", order = 40 )
     var usePPMI = true
@@ -399,7 +399,7 @@ class TextWorld : AttributeContainer, EditableObject {
             tokenVectorMap = TokenVectorMap(tokens, Matrix.eye(tokens.size))
 
         } else {
-            val result = generateCooccurrenceMatrix(docString, windowSize,skipGram, usePPMI)
+            val result = generateCooccurrenceMatrix(docString, windowSize,bidirectional, usePPMI)
             tokenVectorMap = TokenVectorMap(result.first, result.second)
         }
     }

--- a/src/test/kotlin/org/simbrain/util/TextUtilsTest.kt
+++ b/src/test/kotlin/org/simbrain/util/TextUtilsTest.kt
@@ -147,5 +147,24 @@ class TextUtilsTest {
         }
     }
 
+    @Test
+    fun `remove stopwords from matrix`() {
+        val result = generateCooccurrenceMatrix(windowSizeText, 2, true)
+        val coocMatrix = result.second
+        val tokens = result.first
+        val targets = removeStopWords(tokens)
+
+        var approvedIndeces = intArrayOf()
+        for (token in tokens){
+            if (targets.contains(token)) approvedIndeces += intArrayOf(tokens.indexOf(token))
+        }
+        val cooc2 = coocMatrix.rows(*approvedIndeces)
+
+        val cooc3 = removeStopWordsFromMatrix(coocMatrix, tokens)
+
+        assertTrue(cooc2.ncol() == cooc3.ncol())
+        assertTrue(cooc2.nrow() == cooc3.nrow())
+    }
+
 }
 


### PR DESCRIPTION
Changed `skipgram` to `bidirectional` in `textworld`.
Changed the vector query to use rows.
Added parameter to remove stopwords from the co-occurrence matrix. This removes them by rows, which will create an asymmetric matrix.