### PR TITLE
Network canvas theming for light/dark mode

### DIFF
--- a/src/main/java/org/simbrain/network/gui/nodes/InteractionBox.kt
+++ b/src/main/java/org/simbrain/network/gui/nodes/InteractionBox.kt
@@ -7,6 +7,8 @@ import org.piccolo2d.event.PInputEvent
 import org.piccolo2d.nodes.PPath
 import org.piccolo2d.nodes.PText
 import org.simbrain.network.gui.NetworkPanel
+import org.simbrain.util.NetworkTheme
+import org.simbrain.util.blend
 import java.awt.Color
 import java.awt.geom.Rectangle2D
 import java.beans.PropertyChangeEvent
@@ -19,6 +21,10 @@ abstract class InteractionBox(networkPanel: NetworkPanel) : ScreenElement(networ
 
     private val textLabel: PText
     private val kebabMenu: PNode
+    private val dots = mutableListOf<PPath>()
+
+    /** Tab fill color; subclasses override to tint the tab (e.g. supervised models). */
+    protected open val tabFillColor: Color get() = NetworkTheme.current.tabFill
 
     /**
      * Padding values for layout
@@ -59,19 +65,28 @@ abstract class InteractionBox(networkPanel: NetworkPanel) : ScreenElement(networ
      */
     init {
         this.append(rect, false)
-        val color = Color(248, 252, 184)
-        setPaint(color)
-        // setTransparency(.2f);
-        setStrokePaint(Color.GRAY)
-        
         textLabel = PText()
         addChild(textLabel)
-        
+
         // Create kebab menu button
         kebabMenu = createKebabMenu()
         addChild(kebabMenu)
-        
+
+        applyThemeColors()
+
         networkPanel.canvas.camera.addPropertyChangeListener(PCamera.PROPERTY_VIEW_TRANSFORM, zoomListener)
+    }
+
+    /** Re-apply the themed tab colors (fill, border, label, kebab dots). */
+    protected fun applyThemeColors() {
+        setPaint(tabFillColor)
+        setStrokePaint(NetworkTheme.current.subnetOutline)
+        textLabel.textPaint = NetworkTheme.current.tabText
+        dots.forEach { it.setPaint(blend(NetworkTheme.current.tabText, tabFillColor, 0.55)) }
+    }
+
+    override fun refreshTheme() {
+        applyThemeColors()
     }
 
     /**
@@ -86,15 +101,11 @@ abstract class InteractionBox(networkPanel: NetworkPanel) : ScreenElement(networ
         // Set explicit bounds for the menu container with padding for hover area
         menuNode.setBounds(0.0, 0.0, dotSize + (kebabPaddingX * 2), dotsHeight + (kebabPaddingY * 2))
         
-        val dots = mutableListOf<PPath>()
-        val normalDotColor = Color.DARK_GRAY
-        val hoverDotColor = Color.GRAY
-        
         // Calculate starting position for dots
         val dotsStartX = kebabPaddingX
         val dotsStartY = kebabPaddingY
-        
-        // Create three circular dots, arranged vertically
+
+        // Create three circular dots, arranged vertically (colors applied by applyThemeColors)
         for (i in 0..2) {
             val dot = PPath.createEllipse(
                 dotsStartX,
@@ -102,24 +113,23 @@ abstract class InteractionBox(networkPanel: NetworkPanel) : ScreenElement(networ
                 dotSize,
                 dotSize
             )
-            dot.setPaint(normalDotColor)
             dot.setStroke(null) // No border, just filled circles
             dots.add(dot)
             menuNode.addChild(dot)
         }
-        
-        // Add input event handlers for click and hover
+
+        // Add input event handlers for click and hover (hover colors read fresh from the theme)
         menuNode.addInputEventListener(object : PBasicInputEventHandler() {
             override fun mouseClicked(event: PInputEvent) {
                 onKebabMenuClicked(event)
             }
-            
+
             override fun mouseEntered(event: PInputEvent) {
-                dots.forEach { it.setPaint(hoverDotColor) }
+                dots.forEach { it.setPaint(NetworkTheme.current.tabText) }
             }
-            
+
             override fun mouseExited(event: PInputEvent) {
-                dots.forEach { it.setPaint(normalDotColor) }
+                dots.forEach { it.setPaint(blend(NetworkTheme.current.tabText, tabFillColor, 0.55)) }
             }
         })
         

--- a/src/main/java/org/simbrain/network/gui/nodes/InteractionBox.kt
+++ b/src/main/java/org/simbrain/network/gui/nodes/InteractionBox.kt
@@ -8,6 +8,7 @@ import org.piccolo2d.nodes.PPath
 import org.piccolo2d.nodes.PText
 import org.simbrain.network.gui.NetworkPanel
 import org.simbrain.util.NetworkTheme
+import org.simbrain.util.Theme
 import org.simbrain.util.blend
 import java.awt.Color
 import java.awt.geom.Rectangle2D
@@ -65,7 +66,7 @@ abstract class InteractionBox(networkPanel: NetworkPanel) : ScreenElement(networ
      */
     init {
         this.append(rect, false)
-        textLabel = PText()
+        textLabel = PText().apply { font = Theme.body }
         addChild(textLabel)
 
         // Create kebab menu button

--- a/src/main/java/org/simbrain/network/gui/nodes/NeuronCollectionNode.kt
+++ b/src/main/java/org/simbrain/network/gui/nodes/NeuronCollectionNode.kt
@@ -261,7 +261,7 @@ class NeuronCollectionNode(
     // Interaction box
 
     private inner class NeuronCollectionInteractionBox(net: NetworkPanel) : InteractionBox(net) {
-        init { setPaint(Color(209, 255, 204)) }
+        override val tabFillColor: Color get() = NetworkTheme.current.tabFillSupervised
 
         override val propertyDialog get() = this@NeuronCollectionNode.propertyDialog
         override val model get() = this@NeuronCollectionNode.model

--- a/src/main/java/org/simbrain/network/gui/nodes/NodeHandle.java
+++ b/src/main/java/org/simbrain/network/gui/nodes/NodeHandle.java
@@ -3,6 +3,7 @@ package org.simbrain.network.gui.nodes;
 import org.piccolo2d.PNode;
 import org.piccolo2d.extras.handles.PHandle;
 import org.piccolo2d.extras.util.PNodeLocator;
+import org.simbrain.util.NetworkTheme;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
@@ -17,24 +18,24 @@ public class NodeHandle extends PHandle {
 
 
     /**
-     * Green selection handle.
+     * Ordinary selection handle (themed selection color).
      */
     public static final Config SELECTION_STYLE = new Config();
 
     /**
-     * Red "source style" selection handle.
+     * Source-selection handle (themed source color).
      */
-    public static final Config SOURCE_STYLE = new Config(0.2f, Color.RED);
+    public static final Config SOURCE_STYLE = new Config(0.2f, Config.Role.SOURCE);
 
     /**
      * Style used with interaction box selection.
      */
-    public static final Config INTERACTION_BOX_SELECTION_STYLE = new Config(0.01f, 2, Color.green);
+    public static final Config INTERACTION_BOX_SELECTION_STYLE = new Config(0.01f, 2, Config.Role.SELECTION);
 
     /**
      * Style used with interaction box source selection.
      */
-    public static final Config INTERACTION_BOX_SOURCE_STYLE = new Config(0.09f, Color.RED);
+    public static final Config INTERACTION_BOX_SOURCE_STYLE = new Config(0.09f, Config.Role.SOURCE);
 
     /**
      * Regular selections associated with a node.
@@ -69,11 +70,19 @@ public class NodeHandle extends PHandle {
         if (style.thickness > 1) {
             setStroke(new BasicStroke(style.thickness, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND));
         }
-        setStrokePaint(style.selectionColor);
+        setStrokePaint(style.resolveColor());
 
         // Force handle to check its location and size
         updateBounds();
         relocateHandle();
+    }
+
+    /**
+     * Re-resolve this handle's stroke color from the active canvas theme. Called on a live light/dark switch
+     * since handles are plain {@link PHandle} children and are not in the network panel's screen-element sweep.
+     */
+    public void refreshThemeColor() {
+        setStrokePaint(style.resolveColor());
     }
 
     @Override
@@ -191,27 +200,33 @@ public class NodeHandle extends PHandle {
     public static class Config {
 
         /**
+         * Whether a handle marks an ordinary selection or a connection source, determining which themed
+         * canvas color it resolves against.
+         */
+        public enum Role {SELECTION, SOURCE}
+
+        /**
          * Amount of space to add between the selected object and the selection
          * handle.
          */
         private float extensionFactor = 0.075f;
 
         /**
-         * Color of selection boxes.
+         * Role of this handle, mapped to a themed color at paint/refresh time.
          */
-        private Color selectionColor = Color.green;
+        private Role role = Role.SELECTION;
 
         private int thickness = 1;
 
-        public Config(float extensionFactor, int thickness, Color selectionColor) {
+        public Config(float extensionFactor, int thickness, Role role) {
             this.extensionFactor = extensionFactor;
-            this.selectionColor = selectionColor;
+            this.role = role;
             this.thickness = thickness;
         }
 
-        public Config(float extensionFactor, Color selectionColor) {
+        public Config(float extensionFactor, Role role) {
             this.extensionFactor = extensionFactor;
-            this.selectionColor = selectionColor;
+            this.role = role;
         }
 
         public Config() {
@@ -221,8 +236,18 @@ public class NodeHandle extends PHandle {
             return extensionFactor;
         }
 
-        public Color getSelectionColor() {
-            return selectionColor;
+        public Role getRole() {
+            return role;
+        }
+
+        /**
+         * The current themed stroke color for this handle's role, read live from {@link NetworkTheme} so it
+         * always reflects the active light/dark mode.
+         */
+        public Color resolveColor() {
+            return role == Role.SOURCE
+                    ? NetworkTheme.INSTANCE.getCurrent().getSourceHandle()
+                    : NetworkTheme.INSTANCE.getCurrent().getSelectionHandle();
         }
     }
 }

--- a/src/main/java/org/simbrain/util/piccolo/Outline.java
+++ b/src/main/java/org/simbrain/util/piccolo/Outline.java
@@ -4,6 +4,7 @@ import org.piccolo2d.PNode;
 import org.piccolo2d.nodes.PPath;
 import org.piccolo2d.util.PBounds;
 import org.simbrain.network.gui.nodes.ScreenElement;
+import org.simbrain.util.NetworkTheme;
 
 import java.awt.*;
 import java.beans.PropertyChangeListener;
@@ -94,9 +95,14 @@ public class Outline extends PNode {
                 ARC_SIZE,
                 ARC_SIZE
         );
-        outline.setStrokePaint(Color.gray);
+        outline.setStrokePaint(NetworkTheme.INSTANCE.getCurrent().getSubnetOutline());
         outline.setPaint(null);
         addChild(outline);
+    }
+
+    /** Re-apply the themed outline color after a light/dark switch (bounds are unchanged). */
+    public void refreshThemeColor() {
+        outline.setStrokePaint(NetworkTheme.INSTANCE.getCurrent().getSubnetOutline());
     }
 
     public int getOutlinePadding() {

--- a/src/main/java/org/simbrain/util/piccolo/SelectionMarquee.java
+++ b/src/main/java/org/simbrain/util/piccolo/SelectionMarquee.java
@@ -45,7 +45,9 @@ public final class SelectionMarquee extends PPath.Float {
     protected void paint(final PPaintContext paintContext) {
         NetworkTheme.Palette palette = NetworkTheme.INSTANCE.getCurrent();
         Color stroke = palette.getMarquee();
-        Color fill = blend(stroke, palette.getCanvasBackground(), 0.8f);
+        // 20% alpha so the fill composites against whatever is actually beneath the marquee
+        // (network canvas, odor world tiles, customized backgrounds).
+        Color fill = new Color(stroke.getRed(), stroke.getGreen(), stroke.getBlue(), 51);
         Path2D path = getPathReference();
         Graphics2D g2 = paintContext.getGraphics();
 
@@ -55,13 +57,5 @@ public final class SelectionMarquee extends PPath.Float {
         g2.setPaint(stroke);
         g2.setStroke(new PFixedWidthStroke(1.5f));
         g2.draw(path);
-    }
-
-    private static Color blend(final Color a, final Color b, final float bWeight) {
-        float aWeight = 1f - bWeight;
-        return new Color(
-            Math.round(a.getRed() * aWeight + b.getRed() * bWeight),
-            Math.round(a.getGreen() * aWeight + b.getGreen() * bWeight),
-            Math.round(a.getBlue() * aWeight + b.getBlue() * bWeight));
     }
 }

--- a/src/main/java/org/simbrain/util/piccolo/SelectionMarquee.java
+++ b/src/main/java/org/simbrain/util/piccolo/SelectionMarquee.java
@@ -3,6 +3,7 @@ package org.simbrain.util.piccolo;
 import org.piccolo2d.extras.util.PFixedWidthStroke;
 import org.piccolo2d.nodes.PPath;
 import org.piccolo2d.util.PPaintContext;
+import org.simbrain.util.NetworkTheme;
 import org.simbrain.util.Utils;
 
 import java.awt.*;
@@ -15,19 +16,9 @@ import java.awt.geom.Rectangle2D;
 public final class SelectionMarquee extends PPath.Float {
 
     /**
-     * Default paint.
-     */
-    private static final Paint DEFAULT_PAINT = Color.WHITE;
-
-    /**
      * Default stroke.
      */
     private static final Stroke DEFAULT_STROKE = Utils.isMacOSX() ? new BasicStroke(1.0f) : new PFixedWidthStroke(1.0f);
-
-    /**
-     * Color of selection marquee.
-     */
-    private static Color marqueeColor = Color.yellow;
 
     /**
      * Default interior transparency.
@@ -46,37 +37,31 @@ public final class SelectionMarquee extends PPath.Float {
 
         append(new Rectangle2D.Float(x, y, 0.0f, 0.0f), false);
 
-        setPaint(DEFAULT_PAINT);
         setStroke(DEFAULT_STROKE);
-        setStrokePaint(marqueeColor);
         setTransparency(DEFAULT_TRANSPARENCY);
     }
 
     @Override
     protected void paint(final PPaintContext paintContext) {
-        Paint p = getPaint();
-        Stroke stroke = getStroke();
-        Paint strokePaint = getStrokePaint();
+        NetworkTheme.Palette palette = NetworkTheme.INSTANCE.getCurrent();
+        Color stroke = palette.getMarquee();
+        Color fill = blend(stroke, palette.getCanvasBackground(), 0.8f);
         Path2D path = getPathReference();
         Graphics2D g2 = paintContext.getGraphics();
 
-        if (p != null) {
-            g2.setPaint(p);
-            g2.fill(path);
-        }
+        g2.setPaint(fill);
+        g2.fill(path);
 
-        if (stroke != null && strokePaint != null) {
-            g2.setPaint(strokePaint);
-            g2.setStroke(new PFixedWidthStroke(1.5f));
-            g2.draw(path);
-        }
+        g2.setPaint(stroke);
+        g2.setStroke(new PFixedWidthStroke(1.5f));
+        g2.draw(path);
     }
 
-    public static Color getMarqueeColor() {
-        return marqueeColor;
-    }
-
-    public static void setMarqueeColor(final Color marqueeColor) {
-        SelectionMarquee.marqueeColor = marqueeColor;
+    private static Color blend(final Color a, final Color b, final float bWeight) {
+        float aWeight = 1f - bWeight;
+        return new Color(
+            Math.round(a.getRed() * aWeight + b.getRed() * bWeight),
+            Math.round(a.getGreen() * aWeight + b.getGreen() * bWeight),
+            Math.round(a.getBlue() * aWeight + b.getBlue() * bWeight));
     }
 }

--- a/src/main/kotlin/org/simbrain/network/core/NetworkTextObject.kt
+++ b/src/main/kotlin/org/simbrain/network/core/NetworkTextObject.kt
@@ -2,6 +2,7 @@ package org.simbrain.network.core
 
 import org.simbrain.network.events.TextObjectEvents
 import org.simbrain.util.propertyeditor.EditableObject
+import java.awt.Font
 import java.awt.geom.Point2D
 
 /**
@@ -22,7 +23,7 @@ open class NetworkTextObject : EditableObject, LocatableModel {
         }
 
 
-    var fontName: String = "Helvetica"
+    var fontName: String = Font.SANS_SERIF
 
     var fontSize: Int = 12
 

--- a/src/main/kotlin/org/simbrain/network/gui/ArrowButton.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/ArrowButton.kt
@@ -4,13 +4,12 @@ import org.piccolo2d.PNode
 import org.piccolo2d.event.PBasicInputEventHandler
 import org.piccolo2d.event.PInputEvent
 import org.piccolo2d.nodes.PPath
-import java.awt.Color
+import org.piccolo2d.util.PPaintContext
+import org.simbrain.util.NetworkTheme
+import org.simbrain.util.blend
 import java.awt.geom.GeneralPath
 
 enum class ArrowDirection { LEFT, RIGHT, UP, DOWN }
-
-private val NORMAL_COLOR = Color(130, 130, 130)
-private val HOVER_COLOR = Color(50, 50, 50)
 
 /**
  * Create a clickable triangular arrow button.
@@ -55,8 +54,19 @@ fun createArrowButton(direction: ArrowDirection, size: Double = 8.0, onClick: ()
         closePath()
     }
 
-    val arrowPath = PPath.Float(shape)
-    arrowPath.paint = NORMAL_COLOR
+    // Fill the triangle with theme colors read fresh on every paint, so it tracks light/dark — both
+    // its resting and hover state — and recolors on a live theme switch instead of caching colors.
+    val arrowPath = object : PPath.Float(shape) {
+        var hovered = false
+        override fun paint(paintContext: PPaintContext) {
+            paintContext.graphics.paint = if (hovered) {
+                NetworkTheme.current.valueText
+            } else {
+                blend(NetworkTheme.current.valueText, NetworkTheme.current.canvasBackground, 0.5)
+            }
+            paintContext.graphics.fill(pathReference)
+        }
+    }
     arrowPath.stroke = null
 
     val container = PNode()
@@ -69,10 +79,12 @@ fun createArrowButton(direction: ArrowDirection, size: Double = 8.0, onClick: ()
             onClick()
         }
         override fun mouseEntered(event: PInputEvent) {
-            arrowPath.paint = HOVER_COLOR
+            arrowPath.hovered = true
+            arrowPath.invalidatePaint()
         }
         override fun mouseExited(event: PInputEvent) {
-            arrowPath.paint = NORMAL_COLOR
+            arrowPath.hovered = false
+            arrowPath.invalidatePaint()
         }
     })
 

--- a/src/main/kotlin/org/simbrain/network/gui/ImageBox.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/ImageBox.kt
@@ -33,5 +33,9 @@ class ImageBox(val width: Int, val height: Int, thickness: Float) : PNode() {
         addChild(it)
     }
 
+    /** Re-read the boundary color from preferences (e.g. after a light/dark theme switch). */
+    fun updateBorderColorFromPreferences() {
+        box.strokePaint = NetworkPreferences.weightMatrixBoundaryColor
+    }
 
 }

--- a/src/main/kotlin/org/simbrain/network/gui/MouseEventHandler.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/MouseEventHandler.kt
@@ -236,7 +236,7 @@ class MouseEventHandler(val networkPanel: NetworkPanel) : PDragSequenceEventHand
                 customOffsetAnchor.location.y
             ).apply {
                 this.stroke = PPath.DEFAULT_STROKE
-                this.strokePaint = Color.red
+                this.strokePaint = NetworkTheme.current.sourceHandle
             }
             networkPanel.canvas.layer.addChild(placementManagerDelta)
         }

--- a/src/main/kotlin/org/simbrain/network/gui/NetworkPanel.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/NetworkPanel.kt
@@ -190,6 +190,7 @@ class NetworkPanel(val networkComponent: NetworkComponent) : JPanel(), Coroutine
         // neuron fill/outline/text, group/subnet tabs, free text, subnet outlines, and image borders.
         canvas.layer.allNodes.filterIsInstance<Outline>().forEach { it.refreshThemeColor() }
         canvas.layer.allNodes.filterIsInstance<ImageBox>().forEach { it.updateBorderColorFromPreferences() }
+        canvas.layer.allNodes.filterIsInstance<NodeHandle>().forEach { it.refreshThemeColor() }
         screenElements.forEach { it.refreshTheme() }
         canvas.repaint()
     }

--- a/src/main/kotlin/org/simbrain/network/gui/NetworkPanel.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/NetworkPanel.kt
@@ -19,6 +19,7 @@ import org.simbrain.network.smile.ClassifierNetwork
 import org.simbrain.network.subnetworks.*
 import org.simbrain.network.trainers.SupervisedModel
 import org.simbrain.util.*
+import org.simbrain.util.piccolo.Outline
 import org.simbrain.util.piccolo.setViewBoundsNoOverflow
 import org.simbrain.util.piccolo.unionOfGlobalFullBounds
 import org.simbrain.util.widgets.SimbrainToggleButton
@@ -169,13 +170,7 @@ class NetworkPanel(val networkComponent: NetworkComponent) : JPanel(), Coroutine
         SynapseNode.zeroWeightColor = NetworkPreferences.zeroWeightColor
         SynapseNode.minDiameter = NetworkPreferences.minWeightSize
         SynapseNode.maxDiameter = NetworkPreferences.maxWeightSize
-        SynapseNode.zeroWeightColor = NetworkPreferences.zeroWeightColor
 
-        network.flatNeuronList.map {
-            it.events.colorChanged.fire()
-        }
-        // Force update activation text for decimal places preference changes
-        filterScreenElements<NeuronNode>().forEach { it.forceUpdateActivationText() }
         network.flatSynapseList.forEach {
             it.events.colorPreferencesChanged.fire()
         }
@@ -186,19 +181,17 @@ class NetworkPanel(val networkComponent: NetworkComponent) : JPanel(), Coroutine
         network.getModels<TransformerBlock>().forEach {
             it.events.updateGraphics.fire()
         }
-        filterScreenElements<WeightMatrixNode>().forEach {
-            it.updateArrowColorFromPreferences()
-        }
-        filterScreenElements<TensorConnectorNode>().forEach {
-            it.updateArrowColorFromPreferences()
-        }
-        filterScreenElements<FlattenConnectorNode>().forEach {
-            it.updateArrowColorFromPreferences()
-        }
-        filterScreenElements<SmileClassifierNode>().forEach {
-            it.updateArrowColorFromPreferences()
-        }
+        filterScreenElements<WeightMatrixNode>().forEach { it.updateArrowColorFromPreferences() }
+        filterScreenElements<TensorConnectorNode>().forEach { it.updateArrowColorFromPreferences() }
+        filterScreenElements<FlattenConnectorNode>().forEach { it.updateArrowColorFromPreferences() }
+        filterScreenElements<SmileClassifierNode>().forEach { it.updateArrowColorFromPreferences() }
 
+        // Re-apply theme-derived colors that nodes cache at construction (not driven by a model event):
+        // neuron fill/outline/text, group/subnet tabs, free text, subnet outlines, and image borders.
+        canvas.layer.allNodes.filterIsInstance<Outline>().forEach { it.refreshThemeColor() }
+        canvas.layer.allNodes.filterIsInstance<ImageBox>().forEach { it.updateBorderColorFromPreferences() }
+        screenElements.forEach { it.refreshTheme() }
+        canvas.repaint()
     }
 
 

--- a/src/main/kotlin/org/simbrain/network/gui/NetworkPanel.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/NetworkPanel.kt
@@ -181,17 +181,21 @@ class NetworkPanel(val networkComponent: NetworkComponent) : JPanel(), Coroutine
         network.getModels<TransformerBlock>().forEach {
             it.events.updateGraphics.fire()
         }
-        filterScreenElements<WeightMatrixNode>().forEach { it.updateArrowColorFromPreferences() }
-        filterScreenElements<TensorConnectorNode>().forEach { it.updateArrowColorFromPreferences() }
-        filterScreenElements<FlattenConnectorNode>().forEach { it.updateArrowColorFromPreferences() }
-        filterScreenElements<SmileClassifierNode>().forEach { it.updateArrowColorFromPreferences() }
-
         // Re-apply theme-derived colors that nodes cache at construction (not driven by a model event):
-        // neuron fill/outline/text, group/subnet tabs, free text, subnet outlines, and image borders.
-        canvas.layer.allNodes.filterIsInstance<Outline>().forEach { it.refreshThemeColor() }
-        canvas.layer.allNodes.filterIsInstance<ImageBox>().forEach { it.updateBorderColorFromPreferences() }
-        canvas.layer.allNodes.filterIsInstance<NodeHandle>().forEach { it.refreshThemeColor() }
-        screenElements.forEach { it.refreshTheme() }
+        // neuron fill/outline/text, group/subnet tabs, free text, subnet outlines, arrows, and image
+        // borders. A single traversal, since this runs on every preference commit and theme switch.
+        canvas.layer.allNodes.forEach { node ->
+            when (node) {
+                is Outline -> node.refreshThemeColor()
+                is ImageBox -> node.updateBorderColorFromPreferences()
+                is NodeHandle -> node.refreshThemeColor()
+                is WeightMatrixNode -> node.updateArrowColorFromPreferences()
+                is TensorConnectorNode -> node.updateArrowColorFromPreferences()
+                is FlattenConnectorNode -> node.updateArrowColorFromPreferences()
+                is SmileClassifierNode -> node.updateArrowColorFromPreferences()
+            }
+            if (node is ScreenElement) node.refreshTheme()
+        }
         canvas.repaint()
     }
 

--- a/src/main/kotlin/org/simbrain/network/gui/dialogs/NetworkPreferences.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/dialogs/NetworkPreferences.kt
@@ -27,7 +27,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 10
     )
-    var backgroundColor by ColorPreference(Color.WHITE)
+    var backgroundColorTheme by ThemeColorPreference(NetworkTheme.pair { it.canvasBackground })
+    val backgroundColor: Color get() = backgroundColorTheme.resolved
 
     @UserParameter(
         label = "Node hot color",
@@ -35,7 +36,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 20
     )
-    var hotNodeColor by ColorPreference(Color.RED)
+    var hotNodeColorTheme by ThemeColorPreference(NetworkTheme.pair { it.hotNode })
+    val hotNodeColor: Color get() = hotNodeColorTheme.resolved
 
     @UserParameter(
         label = "Node cool color",
@@ -43,7 +45,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 30
     )
-    var coolNodeColor by ColorPreference(Color.BLUE)
+    var coolNodeColorTheme by ThemeColorPreference(NetworkTheme.pair { it.coolNode })
+    val coolNodeColor: Color get() = coolNodeColorTheme.resolved
 
     @UserParameter(
         label = "Connection line color",
@@ -51,7 +54,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 40
     )
-    var connectionLineColor by ColorPreference(Color.BLACK)
+    var connectionLineColorTheme by ThemeColorPreference(NetworkTheme.pair { it.connectionLine })
+    val connectionLineColor: Color get() = connectionLineColorTheme.resolved
 
     @UserParameter(
         label = "Spiking color",
@@ -59,7 +63,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 50
     )
-    var spikingColor by ColorPreference(Color.YELLOW)
+    var spikingColorTheme by ThemeColorPreference(NetworkTheme.pair { it.spiking })
+    val spikingColor: Color get() = spikingColorTheme.resolved
 
     @UserParameter(
         label = "Excitatory color",
@@ -67,7 +72,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 60
     )
-    var excitatorySynapseColor by ColorPreference(Color.RED)
+    var excitatorySynapseColorTheme by ThemeColorPreference(NetworkTheme.pair { it.excitatorySynapse })
+    val excitatorySynapseColor: Color get() = excitatorySynapseColorTheme.resolved
 
     @UserParameter(
         label = "Inhibitory color",
@@ -75,7 +81,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 70
     )
-    var inhibitorySynapseColor by ColorPreference(Color.BLUE)
+    var inhibitorySynapseColorTheme by ThemeColorPreference(NetworkTheme.pair { it.inhibitorySynapse })
+    val inhibitorySynapseColor: Color get() = inhibitorySynapseColorTheme.resolved
 
     @UserParameter(
         label = "Zero color",
@@ -83,7 +90,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 80
     )
-    var zeroWeightColor by ColorPreference(Color.LIGHT_GRAY)
+    var zeroWeightColorTheme by ThemeColorPreference(NetworkTheme.pair { it.zeroWeight })
+    val zeroWeightColor: Color get() = zeroWeightColorTheme.resolved
 
     @UserParameter(
         label = "Weight matrix boundary color",
@@ -91,7 +99,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 90
     )
-    var weightMatrixBoundaryColor by ColorPreference(Color.ORANGE)
+    var weightMatrixBoundaryColorTheme by ThemeColorPreference(NetworkTheme.pair { it.weightMatrixBoundary })
+    val weightMatrixBoundaryColor: Color get() = weightMatrixBoundaryColorTheme.resolved
 
     @UserParameter(
         label = "Synapse group arrow color",
@@ -99,7 +108,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 100
     )
-    var synapseGroupArrowColor by ColorPreference(Color.GREEN)
+    var synapseGroupArrowColorTheme by ThemeColorPreference(NetworkTheme.pair { it.groupArrow })
+    val synapseGroupArrowColor: Color get() = synapseGroupArrowColorTheme.resolved
 
     @UserParameter(
         label = "Connector arrow color",
@@ -107,7 +117,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 110
     )
-    var connectorArrowColor by ColorPreference(Color.ORANGE)
+    var connectorArrowColorTheme by ThemeColorPreference(NetworkTheme.pair { it.connectorArrow })
+    val connectorArrowColor: Color get() = connectorArrowColorTheme.resolved
 
     @UserParameter(
         label = "Receptive field trace color",
@@ -115,7 +126,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 120
     )
-    var receptiveFieldTraceColor by ColorPreference(Color.ORANGE)
+    var receptiveFieldTraceColorTheme by ThemeColorPreference(NetworkTheme.pair { it.receptiveFieldTrace })
+    val receptiveFieldTraceColor: Color get() = receptiveFieldTraceColorTheme.resolved
 
     @UserParameter(
         label = "Backward trace color",
@@ -123,7 +135,8 @@ object NetworkPreferences: PreferenceHolder() {
         tab = "Colors",
         order = 121
     )
-    var backwardTraceColor by ColorPreference(Color(100, 180, 255))
+    var backwardTraceColorTheme by ThemeColorPreference(NetworkTheme.pair { it.backwardTrace })
+    val backwardTraceColor: Color get() = backwardTraceColorTheme.resolved
 
     @UserParameter(
         label = "Receptive field trace mode",

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/ActivationSequenceNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/ActivationSequenceNode.kt
@@ -179,13 +179,8 @@ class ActivationSequenceNode(networkPanel: NetworkPanel, val activationSequence:
         }
         val highlightedRows = activationSequence.highlightedRows
         if (highlightedRows.isNotEmpty()) {
-            drawSequenceHighlight(g2, highlightedRows, emptySet(), ROW_HIGHLIGHT_COLOR, strokeWidth = 1.5f)
+            drawSequenceHighlight(g2, highlightedRows, emptySet(), NetworkTheme.current.rowHighlight, strokeWidth = 1.5f)
         }
-    }
-
-    companion object {
-        /** Outline color for programmatic row highlights (e.g. the current-token row in a language model). */
-        val ROW_HIGHLIGHT_COLOR: Color = Color(0, 200, 255, 160)
     }
 
     /** Draw full-width row outlines and full-height column outlines for trace highlighting. */

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/ActivationSequenceNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/ActivationSequenceNode.kt
@@ -150,6 +150,11 @@ class ActivationSequenceNode(networkPanel: NetworkPanel, val activationSequence:
 
     }
 
+    override fun refreshTheme() {
+        super.refreshTheme()
+        updateActivationImage()
+    }
+
     private fun updateActivationImage() {
         activationImage.removeAllChildren()
         spikeImage.removeAllChildren()

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/ArrayLayerNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/ArrayLayerNode.kt
@@ -9,6 +9,7 @@ import org.simbrain.network.core.ArrayLayer
 import org.simbrain.network.core.LocatableModel
 import org.simbrain.network.core.NeuronArray
 import org.simbrain.network.gui.NetworkPanel
+import org.simbrain.network.gui.dialogs.NetworkPreferences
 import org.simbrain.util.*
 import java.awt.BasicStroke
 import java.awt.Font
@@ -101,6 +102,8 @@ abstract class ArrayLayerNode(networkPanel: NetworkPanel, val layer: ArrayLayer)
         val newBound = mainNode.fullBounds.addPadding(margin)
         val (x, y, w, h) = newBound
         val newBorder = PPath.createRectangle(x, y, w, h)
+        newBorder.paint = NetworkPreferences.backgroundColor
+        newBorder.strokePaint = NetworkTheme.current.nodeOutline
         newBorder.stroke = if (layer.isClamped) {
             CLAMPED_STROKE
         } else {
@@ -140,6 +143,11 @@ abstract class ArrayLayerNode(networkPanel: NetworkPanel, val layer: ArrayLayer)
             RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR
         )
         super.paint(paintContext)
+    }
+
+    override fun refreshTheme() {
+        borderBox.paint = NetworkPreferences.backgroundColor
+        borderBox.strokePaint = NetworkTheme.current.nodeOutline
     }
 
     /**

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/ArrayLayerNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/ArrayLayerNode.kt
@@ -102,8 +102,7 @@ abstract class ArrayLayerNode(networkPanel: NetworkPanel, val layer: ArrayLayer)
         val newBound = mainNode.fullBounds.addPadding(margin)
         val (x, y, w, h) = newBound
         val newBorder = PPath.createRectangle(x, y, w, h)
-        newBorder.paint = NetworkPreferences.backgroundColor
-        newBorder.strokePaint = NetworkTheme.current.nodeOutline
+        newBorder.applyLayerBorderTheme()
         newBorder.stroke = if (layer.isClamped) {
             CLAMPED_STROKE
         } else {
@@ -146,8 +145,7 @@ abstract class ArrayLayerNode(networkPanel: NetworkPanel, val layer: ArrayLayer)
     }
 
     override fun refreshTheme() {
-        borderBox.paint = NetworkPreferences.backgroundColor
-        borderBox.strokePaint = NetworkTheme.current.nodeOutline
+        borderBox.applyLayerBorderTheme()
     }
 
     /**
@@ -167,4 +165,9 @@ abstract class ArrayLayerNode(networkPanel: NetworkPanel, val layer: ArrayLayer)
 
     }
 
+}
+/** Themed fill and outline for the border box around an array layer node. */
+fun PPath.applyLayerBorderTheme() {
+    paint = NetworkPreferences.backgroundColor
+    strokePaint = NetworkTheme.current.nodeOutline
 }

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/NeuronArrayNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/NeuronArrayNode.kt
@@ -289,6 +289,17 @@ class NeuronArrayNode(networkPanel: NetworkPanel, val neuronArray: NeuronArray) 
 
     }
 
+    override fun refreshTheme() {
+        super.refreshTheme()
+        updateActivationImage()
+        if (neuronArray.circleMode) {
+            val acts = neuronArray.activations.toDoubleArray()
+            neuronCircles.forEachIndexed { i, circle ->
+                circle.drawActivation(acts.getOrElse(i) { 0.0 }, neuronArray.updateRule.graphicalBounds)
+            }
+        }
+    }
+
     private fun updateActivationImage() {
         activationImage.removeAllChildren()
         spikeImage.removeAllChildren()

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/NeuronCircleNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/NeuronCircleNode.kt
@@ -5,6 +5,7 @@ import org.piccolo2d.nodes.PText
 import org.piccolo2d.util.PPaintContext
 import org.simbrain.network.gui.NetworkPanel
 import org.simbrain.network.gui.dialogs.NetworkPreferences
+import org.simbrain.util.NetworkTheme
 import org.simbrain.util.Theme
 import org.simbrain.util.format
 import org.simbrain.util.getColorGradient
@@ -52,11 +53,13 @@ class NeuronCircleNode(val networkPanel: NetworkPanel): PPath.Double() {
 
     private val activationText = PText().also {
         it.font = NEURON_FONT_BOLD
+        it.textPaint = NetworkTheme.current.valueText
         addChild(it)
     }
 
     private val labelText = PText().also {
         it.font = NEURON_FONT
+        it.textPaint = NetworkTheme.current.valueText
         addChild(it)
     }
 
@@ -97,7 +100,7 @@ class NeuronCircleNode(val networkPanel: NetworkPanel): PPath.Double() {
                 return
             }
             if (value == null) {
-                mainNode.strokePaint = Color.BLACK
+                mainNode.strokePaint = NetworkTheme.current.nodeOutline
             } else {
                 mainNode.strokePaint = value
             }
@@ -111,6 +114,8 @@ class NeuronCircleNode(val networkPanel: NetworkPanel): PPath.Double() {
     fun drawActivation(activation: kotlin.Double, graphicalBounds: ClosedFloatingPointRange<kotlin.Double>) {
         this.activation = activation
         this.graphicalBounds = graphicalBounds
+        activationText.textPaint = NetworkTheme.current.valueText
+        labelText.textPaint = NetworkTheme.current.valueText
         updatePaint(activation.getColorGradient(graphicalBounds, NetworkPreferences.coolNodeColor, NetworkPreferences.hotNodeColor))
         updateStroke()
 

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/NeuronNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/NeuronNode.kt
@@ -160,4 +160,10 @@ class NeuronNode(net: NetworkPanel, val neuron: Neuron) : ScreenElement(net) {
         return true
     }
 
+    override fun refreshTheme() {
+        updatePolarity()
+        updateActivation()
+        updateTextLabel()
+    }
+
 }

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/ScreenElement.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/ScreenElement.kt
@@ -142,4 +142,11 @@ abstract class ScreenElement protected constructor(val networkPanel: NetworkPane
     fun select() {
         networkPanel.selectionManager.add(this)
     }
+
+    /**
+     * Re-apply theme-derived colors after a light/dark switch. Default does nothing; nodes that cache
+     * themed paints (rather than re-reading them on a model event) override this to re-set them. Invoked
+     * by [NetworkPanel] when the canvas is recolored.
+     */
+    open fun refreshTheme() {}
 }

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/SupervisedModelNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/SupervisedModelNode.kt
@@ -7,12 +7,13 @@ import org.simbrain.network.events.LocationEvents
 import org.simbrain.network.gui.NetworkPanel
 import org.simbrain.network.gui.dialogs.getSupervisedTrainingDialog
 import org.simbrain.network.trainers.SupervisedModel
+import org.simbrain.util.NetworkTheme
 import org.simbrain.util.StandardDialog
 import org.simbrain.util.createAction
+import java.awt.Color
 import org.simbrain.util.piccolo.Outline
 import org.simbrain.util.showInputDialog
 import org.simbrain.util.swingDispatcher
-import java.awt.Color
 import javax.swing.JComponent
 import javax.swing.JPopupMenu
 
@@ -138,7 +139,6 @@ class SupervisedModelNode(networkPanel: NetworkPanel, val supervisedModel: Super
 
     init {
         interactionBox.setText(supervisedModel.displayName)
-        interactionBox.paint = Color(209, 255, 204)
         addChild(outline)
         addChild(interactionBox)
 
@@ -168,6 +168,8 @@ class SupervisedModelNode(networkPanel: NetworkPanel, val supervisedModel: Super
      * appears when the box is double-clicked.
      */
     inner class SupervisedModelNodeInteractionBox(net: NetworkPanel) : InteractionBox(net) {
+
+        override val tabFillColor: Color get() = NetworkTheme.current.tabFillSupervised
 
         override val contextMenu: JPopupMenu
             get() = this@SupervisedModelNode.contextMenu

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseGroupNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseGroupNode.kt
@@ -142,6 +142,10 @@ class SynapseGroupNode(networkPanel: NetworkPanel, val synapseGroup: SynapseGrou
         interactionBox.setText(synapseGroup.displayName)
     }
 
+    override fun refreshTheme() {
+        directedNode?.updateColorFromPreferences()
+    }
+
     override val isDraggable: Boolean = false
 
     override val model: SynapseGroup

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseGroupNodeDirected.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseGroupNodeDirected.kt
@@ -56,14 +56,13 @@ class SynapseGroupNodeDirected(private val synapseGroupNode: SynapseGroupNode) :
         }
     }
 
-    /** Re-read the themed [NetworkPreferences.synapseGroupArrowColor] and relayout (e.g. after a light/dark switch). */
+    /** Re-read the themed [NetworkPreferences.synapseGroupArrowColor] (e.g. after a light/dark switch). */
     fun updateColorFromPreferences() {
         val color = NetworkPreferences.synapseGroupArrowColor
         when (arrow) {
             is RecurrentArrow -> arrow.updateColor(color)
             is BezierArrow -> arrow.updateColor(color)
         }
-        layoutChildren()
     }
 
 }

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseGroupNodeDirected.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseGroupNodeDirected.kt
@@ -56,4 +56,14 @@ class SynapseGroupNodeDirected(private val synapseGroupNode: SynapseGroupNode) :
         }
     }
 
+    /** Re-read the themed [NetworkPreferences.synapseGroupArrowColor] and relayout (e.g. after a light/dark switch). */
+    fun updateColorFromPreferences() {
+        val color = NetworkPreferences.synapseGroupArrowColor
+        when (arrow) {
+            is RecurrentArrow -> arrow.updateColor(color)
+            is BezierArrow -> arrow.updateColor(color)
+        }
+        layoutChildren()
+    }
+
 }

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/SynapseNode.kt
@@ -16,10 +16,7 @@ import org.simbrain.network.gui.dialogs.NetworkPreferences.maxWeightSize
 import org.simbrain.network.gui.dialogs.NetworkPreferences.minWeightSize
 import org.simbrain.network.gui.dialogs.NetworkPreferences.spikingColor
 import org.simbrain.network.gui.dialogs.synapse.SynapseDialog
-import org.simbrain.util.StandardDialog
-import org.simbrain.util.computeCellFont
-import org.simbrain.util.drawCenteredOutlinedLabel
-import org.simbrain.util.format
+import org.simbrain.util.*
 import java.awt.Color
 import java.awt.geom.Arc2D
 import java.awt.geom.Area
@@ -161,10 +158,15 @@ class SynapseNode(
 
     fun updateClampStatus() {
         if (synapse.clamped) {
-            circle!!.strokePaint = Color.black
+            circle!!.strokePaint = NetworkTheme.current.nodeOutline
         } else {
             circle!!.strokePaint = null
         }
+    }
+
+    override fun refreshTheme() {
+        super.refreshTheme()
+        updateClampStatus()
     }
 
     val isSelfConnection: Boolean

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TensorConnectorNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TensorConnectorNode.kt
@@ -3,6 +3,7 @@ package org.simbrain.network.gui.nodes
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.swing.Swing
 import org.piccolo2d.PNode
+import org.piccolo2d.nodes.PPath
 import org.piccolo2d.nodes.PText
 import org.piccolo2d.util.PBounds
 import org.piccolo2d.util.PPaintContext
@@ -276,6 +277,12 @@ class TensorConnectorNode(networkPanel: NetworkPanel, val connector: TensorConne
         renderKernelGrid()
         updateArrowColorFromPreferences()
         updateDetailLabel()
+        kernelGridGroup.allNodes.forEach { node ->
+            when (node) {
+                is PText -> node.textPaint = NetworkTheme.current.valueText
+                is PPath -> node.strokePaint = NetworkTheme.current.imageBorder
+            }
+        }
     }
 
     fun renderKernelImage() {

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TensorConnectorNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TensorConnectorNode.kt
@@ -37,6 +37,7 @@ class TensorConnectorNode(networkPanel: NetworkPanel, val connector: TensorConne
     /** Detail label for filter/channel info (ConvolutionConnector only). */
     private val detailLabel = PText("").apply {
         font = Theme.small
+        textPaint = NetworkTheme.current.valueText
     }
 
     /** For ConvolutionConnector: delegates to model state. */
@@ -96,6 +97,7 @@ class TensorConnectorNode(networkPanel: NetworkPanel, val connector: TensorConne
         for (c in 0 until inputChannels) {
             val label = PText("C${c + 1}").apply {
                 font = Theme.font(7)
+                textPaint = NetworkTheme.current.valueText
             }
             label.setOffset(
                 labelOffset + c * (cellSize + gap) + (cellSize - label.width) / 2,
@@ -108,6 +110,7 @@ class TensorConnectorNode(networkPanel: NetworkPanel, val connector: TensorConne
         for (f in 0 until numFilters) {
             val label = PText("F${f + 1}").apply {
                 font = Theme.font(7)
+                textPaint = NetworkTheme.current.valueText
             }
             label.setOffset(
                 0.0,
@@ -128,7 +131,7 @@ class TensorConnectorNode(networkPanel: NetworkPanel, val connector: TensorConne
                 // Thin border
                 val border = createRectangle(x, y, cellSize, cellSize)
                 border.paint = null
-                border.strokePaint = Color.GRAY
+                border.strokePaint = NetworkTheme.current.imageBorder
                 border.stroke = BasicStroke(0.5f)
                 kernelGridGroup.addChild(border)
 
@@ -268,6 +271,13 @@ class TensorConnectorNode(networkPanel: NetworkPanel, val connector: TensorConne
     /** Trace highlight set by the receptive field tracer. */
     var traceHighlight: ConnectorTraceHighlight? = null
 
+    override fun refreshTheme() {
+        renderKernelImage()
+        renderKernelGrid()
+        updateArrowColorFromPreferences()
+        updateDetailLabel()
+    }
+
     fun renderKernelImage() {
         val conv = connector as? ConvolutionConnector ?: return
         val slice = kernelSlice ?: return
@@ -351,6 +361,7 @@ class TensorConnectorNode(networkPanel: NetworkPanel, val connector: TensorConne
     }
 
     fun updateDetailLabel() {
+        detailLabel.textPaint = NetworkTheme.current.valueText
         if (connector is ConvolutionConnector) {
             val c = connector
             detailLabel.text = "F${currentFilter + 1}/${c.numFilters} Ch${currentInputChannel + 1}/${c.source.shape.channels}"

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TensorNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TensorNode.kt
@@ -166,8 +166,7 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
     }
 
     override fun refreshTheme() {
-        borderBox.paint = NetworkPreferences.backgroundColor
-        borderBox.strokePaint = NetworkTheme.current.nodeOutline
+        borderBox.applyLayerBorderTheme()
         updateActivationImage()
     }
 
@@ -317,8 +316,7 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
         val newBound = mainNode.fullBounds.addPadding(margin)
         val (x, y, w, h) = newBound
         val newBorder = createRectangle(x, y, w, h)
-        newBorder.paint = NetworkPreferences.backgroundColor
-        newBorder.strokePaint = NetworkTheme.current.nodeOutline
+        newBorder.applyLayerBorderTheme()
         newBorder.stroke = if (tensorLayer.isClamped) BasicStroke(2f) else DEFAULT_STROKE
         return newBorder
     }

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TensorNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TensorNode.kt
@@ -265,6 +265,7 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
         }
 
         channelLabel.visible = true
+        channelLabel.textPaint = NetworkTheme.current.valueText
         channelLabel.text = if (tensorLayer.rgbComposite && tensorLayer.shape.channels == 3) {
             "RGB Composite"
         } else {

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TensorNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TensorNode.kt
@@ -58,6 +58,7 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
     }
     private val channelLabel = PText("").apply {
         font = Theme.label
+        textPaint = NetworkTheme.current.valueText
         mainNode.addChild(this)
     }
 
@@ -101,7 +102,7 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
         val x = thumbStartX + c * (thumbSize + thumbGap)
         PPath.createRectangle(x, thumbStripY, thumbSize, thumbSize).apply {
             paint = null
-            strokePaint = Color.GRAY
+            strokePaint = NetworkTheme.current.imageBorder
             stroke = BasicStroke(1f)
             thumbnailStripNode.addChild(this)
         }
@@ -162,6 +163,12 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
                 channelBuffer[h * tensorLayer.shape.width + w] = tensorLayer.activations[tensorLayer.shape.index(h, w, c)]
             }
         }
+    }
+
+    override fun refreshTheme() {
+        borderBox.paint = NetworkPreferences.backgroundColor
+        borderBox.strokePaint = NetworkTheme.current.nodeOutline
+        updateActivationImage()
     }
 
     private fun updateActivationImage() {
@@ -235,12 +242,12 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
             channelBuffer.writeSimbrainColorImage(thumbImages[c])
             thumbPImages[c].invalidatePaint()
 
-            // Update border: orange for selected, gray for others
+            // Update border: highlight for selected, default for others
             if (c == selectedCh) {
-                thumbBorders[c].strokePaint = Color.ORANGE
+                thumbBorders[c].strokePaint = NetworkTheme.current.weightMatrixBoundary
                 thumbBorders[c].stroke = BasicStroke(2f)
             } else {
-                thumbBorders[c].strokePaint = Color.GRAY
+                thumbBorders[c].strokePaint = NetworkTheme.current.imageBorder
                 thumbBorders[c].stroke = BasicStroke(1f)
             }
         }
@@ -309,6 +316,8 @@ class TensorNode(networkPanel: NetworkPanel, val tensorLayer: TensorLayer) : Scr
         val newBound = mainNode.fullBounds.addPadding(margin)
         val (x, y, w, h) = newBound
         val newBorder = createRectangle(x, y, w, h)
+        newBorder.paint = NetworkPreferences.backgroundColor
+        newBorder.strokePaint = NetworkTheme.current.nodeOutline
         newBorder.stroke = if (tensorLayer.isClamped) BasicStroke(2f) else DEFAULT_STROKE
         return newBorder
     }

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TextNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TextNode.kt
@@ -83,6 +83,7 @@ open class TextNode(
     fun update() {
         try {
             val simpleAttributeSet = createAttributeSet(textObject.fontName, textObject.fontSize, textObject.isItalic, textObject.isBold)
+            StyleConstants.setForeground(simpleAttributeSet, NetworkTheme.current.valueText)
             pStyledText.document.remove(0, pStyledText.document.length)
             pStyledText.document.insertString(0, textObject.text, simpleAttributeSet)
             pStyledText.syncWithDocument()
@@ -90,6 +91,10 @@ open class TextNode(
         } catch (e: BadLocationException) {
             e.printStackTrace()
         }
+    }
+
+    override fun refreshTheme() {
+        update()
     }
 
     override fun offset(dx: kotlin.Double, dy: kotlin.Double) {

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TransformerBlockNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TransformerBlockNode.kt
@@ -186,6 +186,7 @@ class TransformerBlockNode(networkPanel: NetworkPanel, val transformerBlock: Tra
     override fun refreshTheme() {
         super.refreshTheme()
         updateImages()
+        mainNode.allNodes.filterIsInstance<PText>().forEach { it.textPaint = NetworkTheme.current.valueText }
     }
 
     private fun updateImages() {

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TransformerBlockNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TransformerBlockNode.kt
@@ -569,19 +569,19 @@ class TransformerBlockNode(networkPanel: NetworkPanel, val transformerBlock: Tra
             return this
         }
         
-        fun build(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = Color.GRAY): Arrow {
+        fun build(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = NetworkTheme.current.connectionLine): Arrow {
             return Arrow(points.toList(), ArrowType.ARROWHEAD, strokeWidth = strokeWidth, strokeColor = strokeColor)
         }
         
-        fun buildWithoutArrowhead(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = Color.GRAY): Arrow {
+        fun buildWithoutArrowhead(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = NetworkTheme.current.connectionLine): Arrow {
             return Arrow(points.toList(), ArrowType.NONE, strokeWidth = strokeWidth, strokeColor = strokeColor)
         }
         
-        fun buildWithJunction(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = Color.GRAY): Arrow {
+        fun buildWithJunction(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = NetworkTheme.current.connectionLine): Arrow {
             return Arrow(points.toList(), ArrowType.JUNCTION, strokeWidth = strokeWidth, strokeColor = strokeColor)
         }
         
-        fun buildWithMultiply(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = Color.GRAY): Arrow {
+        fun buildWithMultiply(strokeWidth: kotlin.Float = 1.0f, strokeColor: Color = NetworkTheme.current.connectionLine): Arrow {
             return Arrow(points.toList(), ArrowType.MULTIPLY, strokeWidth = strokeWidth, strokeColor = strokeColor)
         }
     }
@@ -611,7 +611,7 @@ class TransformerBlockNode(networkPanel: NetworkPanel, val transformerBlock: Tra
         private val path: List<Point2D>, 
         private val arrowType: ArrowType = ArrowType.ARROWHEAD,
         private val strokeWidth: kotlin.Float = 1.0f,
-        private val strokeColor: Color = Color.GRAY
+        private val strokeColor: Color = NetworkTheme.current.connectionLine
     ): PNode() {
         
         private val arrowHeadSize = 5.0

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/TransformerBlockNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/TransformerBlockNode.kt
@@ -183,6 +183,11 @@ class TransformerBlockNode(networkPanel: NetworkPanel, val transformerBlock: Tra
         updateTextLabels()
     }
 
+    override fun refreshTheme() {
+        super.refreshTheme()
+        updateImages()
+    }
+
     private fun updateImages() {
 
 
@@ -488,6 +493,7 @@ class TransformerBlockNode(networkPanel: NetworkPanel, val transformerBlock: Tra
         val label = PText().apply {
             this.text = text
             font = INFO_FONT
+            textPaint = NetworkTheme.current.valueText
         }
         addChild(label)
         return label
@@ -680,7 +686,7 @@ class TransformerBlockNode(networkPanel: NetworkPanel, val transformerBlock: Tra
                     
                     // Draw filled white circle
                     val originalFillColor = g2.color
-                    g2.color = Color.WHITE
+                    g2.color = NetworkTheme.current.canvasBackground
                     g2.fillOval(
                         (lastPoint.x - junctionRadius).toInt(),
                         (lastPoint.y - junctionRadius).toInt(),
@@ -719,7 +725,7 @@ class TransformerBlockNode(networkPanel: NetworkPanel, val transformerBlock: Tra
                     
                     // Draw filled white circle
                     val originalFillColor = g2.color
-                    g2.color = Color.WHITE
+                    g2.color = NetworkTheme.current.canvasBackground
                     g2.fillOval(
                         (lastPoint.x - junctionRadius).toInt(),
                         (lastPoint.y - junctionRadius).toInt(),

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/WeightMatrixNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/WeightMatrixNode.kt
@@ -510,7 +510,7 @@ class WeightMatrixNode(networkPanel: NetworkPanel, val weightMatrix: Connector) 
     fun setClamped(clamped: Boolean) {
         if (clamped) {
             imageBox.box.stroke = BasicStroke(4.0f)
-            imageBox.box.strokePaint = Color.BLACK
+            imageBox.box.strokePaint = NetworkTheme.current.nodeOutline
         } else {
             imageBox.box.stroke = BasicStroke(1.0f)
             imageBox.box.strokePaint = NetworkPreferences.weightMatrixBoundaryColor

--- a/src/main/kotlin/org/simbrain/network/gui/nodes/WeightMatrixNode.kt
+++ b/src/main/kotlin/org/simbrain/network/gui/nodes/WeightMatrixNode.kt
@@ -170,6 +170,12 @@ class WeightMatrixNode(networkPanel: NetworkPanel, val weightMatrix: Connector) 
         arrow.updateColorFromPreferences()
     }
 
+    override fun refreshTheme() {
+        renderMatrixToImage()
+        updateArrowColorFromPreferences()
+        setClamped((weightMatrix as WeightMatrix).clamped)
+    }
+
     /**
      * Render the weight matrix to the [.imageBox].
      *

--- a/src/main/kotlin/org/simbrain/util/ImageUtils.kt
+++ b/src/main/kotlin/org/simbrain/util/ImageUtils.kt
@@ -17,13 +17,32 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.random.Random
 
-fun Double.getColorGradient(range: ClosedFloatingPointRange<Double>, lowColor: Color, highColor: Color) = clip(range).let {
-    if (it < 0) {
-        val (h, s, v) = lowColor.toHSB()
-        Color.getHSBColor(h, SimbrainMath.rescale(-it, 0.0, -range.start, 0.0, s.toDouble()).toFloat(), v)
-    } else {
-        val (h, s, v) = highColor.toHSB()
-        Color.getHSBColor(h, SimbrainMath.rescale(it, 0.0, range.endInclusive, 0.0, s.toDouble()).toFloat(), v)
+/** Linear RGB interpolation from [from] to [to] by [t] (0..1), packed as an opaque ARGB int. */
+private fun lerpRgb(from: Color, to: Color, t: Float): Int {
+    val tc = if (t < 0f) 0f else if (t > 1f) 1f else t
+    val r = (from.red + (to.red - from.red) * tc).toInt()
+    val g = (from.green + (to.green - from.green) * tc).toInt()
+    val b = (from.blue + (to.blue - from.blue) * tc).toInt()
+    return -0x1000000 or (r shl 16) or (g shl 8) or b
+}
+
+/**
+ * Maps a signed value to a diverging color: [lowColor] at the low end of [range], [midColor] (the
+ * theme's neutral midpoint, matched to the canvas background) at zero, [highColor] at the high end.
+ * Because zero maps to a background-matched neutral, resting/zero values recede instead of glowing on
+ * either a light or dark canvas (the old mapping desaturated toward white at zero).
+ */
+fun Double.getColorGradient(
+    range: ClosedFloatingPointRange<Double>,
+    lowColor: Color,
+    highColor: Color,
+    midColor: Color = NetworkTheme.current.neutralMidpoint,
+): Color {
+    val v = coerceIn(range)
+    return when {
+        v < 0 && range.start < 0 -> Color(lerpRgb(midColor, lowColor, (v / range.start).toFloat()))
+        v > 0 && range.endInclusive > 0 -> Color(lerpRgb(midColor, highColor, (v / range.endInclusive).toFloat()))
+        else -> midColor
     }
 }
 
@@ -35,32 +54,54 @@ fun Double.toSimbrainColor(range: ClosedFloatingPointRange<Double>, coolHue: Flo
     }
 }
 
-fun Float.toSimbrainColor() = clip(-1.0f..1.0f).let {
-    if (it < 0) Color.HSBtoRGB(2/3f, -it, 1.0f) else Color.HSBtoRGB(0.0f, it, 1.0f)
+/**
+ * Diverging color for a value in -1..1 packed as an opaque ARGB int: [neg] at -1, [mid] at 0, [pos] at
+ * +1 (see [getColorGradient]). The defaults track the active theme so bitmaps recede at zero on either
+ * background instead of glowing white.
+ */
+fun Float.toSimbrainColor(
+    neg: Color = NetworkTheme.current.coolNode,
+    mid: Color = NetworkTheme.current.neutralMidpoint,
+    pos: Color = NetworkTheme.current.hotNode,
+): Int {
+    val v = if (this < -1f) -1f else if (this > 1f) 1f else this
+    return if (v < 0) lerpRgb(mid, neg, -v) else lerpRgb(mid, pos, v)
 }
 
-fun Double.toSimbrainColor() = toFloat().toSimbrainColor()
+fun Double.toSimbrainColor(
+    neg: Color = NetworkTheme.current.coolNode,
+    mid: Color = NetworkTheme.current.neutralMidpoint,
+    pos: Color = NetworkTheme.current.hotNode,
+) = toFloat().toSimbrainColor(neg, mid, pos)
 
-/**
- * Convert array of float values to array of RGB color values.
- */
-fun FloatArray.toSimbrainColor() = map { it.toSimbrainColor() }.toIntArray()
+/** Convert an array of values in -1..1 to packed ARGB ints (theme colors resolved once for the array). */
+fun FloatArray.toSimbrainColor(
+    neg: Color = NetworkTheme.current.coolNode,
+    mid: Color = NetworkTheme.current.neutralMidpoint,
+    pos: Color = NetworkTheme.current.hotNode,
+) = IntArray(size) { this[it].toSimbrainColor(neg, mid, pos) }
 
-/**
- * Convert array of double values to array of RGB color values.
- */
-fun DoubleArray.toSimbrainColor() = map { it.toSimbrainColor() }.toIntArray()
+fun DoubleArray.toSimbrainColor(
+    neg: Color = NetworkTheme.current.coolNode,
+    mid: Color = NetworkTheme.current.neutralMidpoint,
+    pos: Color = NetworkTheme.current.hotNode,
+) = IntArray(size) { this[it].toSimbrainColor(neg, mid, pos) }
 
 /**
  * Converts a double array to matrix representation (as a Buffered Image) with a specified width and height, in pixels.
  *
  * Width * height must be less than the array size.
  */
-fun DoubleArray.toSimbrainColorImage(width: Int, height: Int) = IntArray(width * height).let {
+fun DoubleArray.toSimbrainColorImage(
+    width: Int, height: Int,
+    neg: Color = NetworkTheme.current.coolNode,
+    mid: Color = NetworkTheme.current.neutralMidpoint,
+    pos: Color = NetworkTheme.current.hotNode,
+) = IntArray(width * height).let {
     if (this.size < it.size) {
-        it.fill(Color.lightGray.rgb, this.size, it.size)
+        it.fill(mid.rgb, this.size, it.size)
     }
-    System.arraycopy(toSimbrainColor(), 0, it, 0, min(size, width * height))
+    System.arraycopy(toSimbrainColor(neg, mid, pos), 0, it, 0, min(size, width * height))
     val colorModel: ColorModel = DirectColorModel(24, 0xff0000, 0x00ff00, 0x0000ff)
     val sampleModel = colorModel.createCompatibleSampleModel(width, height)
     val raster = Raster.createWritableRaster(sampleModel, DataBufferInt(it, width * height), null)
@@ -71,22 +112,32 @@ fun DoubleArray.toSimbrainColorImage(width: Int, height: Int) = IntArray(width *
  * Write Simbrain color values directly into the backing array of [dest], avoiding all intermediate allocations.
  * [dest] should be a [BufferedImage.TYPE_INT_RGB] image whose dimensions match the data.
  */
-fun DoubleArray.writeSimbrainColorImage(dest: BufferedImage) {
+fun DoubleArray.writeSimbrainColorImage(
+    dest: BufferedImage,
+    neg: Color = NetworkTheme.current.coolNode,
+    mid: Color = NetworkTheme.current.neutralMidpoint,
+    pos: Color = NetworkTheme.current.hotNode,
+) {
     val pixels = (dest.raster.dataBuffer as DataBufferInt).data
     val len = min(size, pixels.size)
     for (i in 0 until len) {
-        pixels[i] = this[i].toSimbrainColor()
+        pixels[i] = this[i].toSimbrainColor(neg, mid, pos)
     }
     if (size < pixels.size) {
-        pixels.fill(Color.lightGray.rgb, size, pixels.size)
+        pixels.fill(mid.rgb, size, pixels.size)
     }
 }
 
 /**
  * Converts a float array to a matrix image as in [DoubleArray.toSimbrainColorImage]
  */
-fun FloatArray.toSimbrainColorImage(width: Int, height: Int) = IntArray(width * height).let {
-    System.arraycopy(toSimbrainColor(), 0, it, 0, min(size, width * height))
+fun FloatArray.toSimbrainColorImage(
+    width: Int, height: Int,
+    neg: Color = NetworkTheme.current.coolNode,
+    mid: Color = NetworkTheme.current.neutralMidpoint,
+    pos: Color = NetworkTheme.current.hotNode,
+) = IntArray(width * height).let {
+    System.arraycopy(toSimbrainColor(neg, mid, pos), 0, it, 0, min(size, width * height))
     val colorModel: ColorModel = DirectColorModel(24, 0xff0000, 0x00ff00, 0x0000ff)
     val sampleModel = colorModel.createCompatibleSampleModel(width, height)
     val raster = Raster.createWritableRaster(sampleModel, DataBufferInt(it, width * height), null)
@@ -376,8 +427,9 @@ fun computeCellFont(targetWidth: Double, targetHeight: Double, refString: String
 }
 
 /**
- * Draw [text] centered at ([centerX], [centerY]) as black with a white outline for readability on any background.
- * Sets antialiasing hints and modifies stroke/color on the receiver.
+ * Draw [text] centered at ([centerX], [centerY]) in the themed value color with a halo in the themed
+ * canvas color for readability on any background. Sets antialiasing hints and modifies stroke/color on
+ * the receiver.
  */
 fun Graphics2D.drawCenteredOutlinedLabel(text: String, font: Font, centerX: Double, centerY: Double) {
     if (text.isEmpty()) return
@@ -391,15 +443,16 @@ fun Graphics2D.drawCenteredOutlinedLabel(text: String, font: Font, centerX: Doub
     setRenderingHint(RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON)
 
     stroke = BasicStroke(font.size2D * 0.15f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND)
-    color = Color.WHITE
+    color = NetworkTheme.current.canvasBackground
     draw(outline)
-    color = Color.BLACK
+    color = NetworkTheme.current.valueText
     fill(outline)
 }
 
 /**
  * Draw numeric value labels over a grid of cells. Only cells visible in the current clip are drawn.
- * Text is rendered as black with a white outline for readability over any background color.
+ * Text is rendered in the themed value color with a halo in the themed canvas color for readability
+ * over any background color.
  * Font size is computed once from a worst-case reference string so that all cells use the same size.
  */
 fun Graphics2D.drawNumericOverlay(

--- a/src/main/kotlin/org/simbrain/util/ImageUtils.kt
+++ b/src/main/kotlin/org/simbrain/util/ImageUtils.kt
@@ -19,7 +19,7 @@ import kotlin.random.Random
 
 /** Linear RGB interpolation from [from] to [to] by [t] (0..1), packed as an opaque ARGB int. */
 private fun lerpRgb(from: Color, to: Color, t: Float): Int {
-    val tc = if (t < 0f) 0f else if (t > 1f) 1f else t
+    val tc = t.coerceIn(0f, 1f)
     val r = (from.red + (to.red - from.red) * tc).toInt()
     val g = (from.green + (to.green - from.green) * tc).toInt()
     val b = (from.blue + (to.blue - from.blue) * tc).toInt()
@@ -38,7 +38,7 @@ fun Double.getColorGradient(
     highColor: Color,
     midColor: Color = NetworkTheme.current.neutralMidpoint,
 ): Color {
-    val v = coerceIn(range)
+    val v = clip(range)
     return when {
         v < 0 && range.start < 0 -> Color(lerpRgb(midColor, lowColor, (v / range.start).toFloat()))
         v > 0 && range.endInclusive > 0 -> Color(lerpRgb(midColor, highColor, (v / range.endInclusive).toFloat()))
@@ -64,7 +64,7 @@ fun Float.toSimbrainColor(
     mid: Color = NetworkTheme.current.neutralMidpoint,
     pos: Color = NetworkTheme.current.hotNode,
 ): Int {
-    val v = if (this < -1f) -1f else if (this > 1f) 1f else this
+    val v = coerceIn(-1f, 1f)
     return if (v < 0) lerpRgb(mid, neg, -v) else lerpRgb(mid, pos, v)
 }
 

--- a/src/main/kotlin/org/simbrain/util/NetworkTheme.kt
+++ b/src/main/kotlin/org/simbrain/util/NetworkTheme.kt
@@ -1,5 +1,8 @@
 package org.simbrain.util
 
+import org.simbrain.util.NetworkTheme.current
+import org.simbrain.util.NetworkTheme.darkPalette
+import org.simbrain.util.NetworkTheme.lightPalette
 import java.awt.Color
 import javax.swing.UIManager
 
@@ -61,18 +64,18 @@ object NetworkTheme {
         subnetOutline = Color(0x8C8C8C),
         selectionHandle = Color(0x0A84FF),
         sourceHandle = Color(0xD32F2F),
-        hotNode = Color(0xB2182B),
-        coolNode = Color(0x2166AC),
+        hotNode = Color(0xD5584F),
+        coolNode = Color(0x5082C4),
         neutralMidpoint = Color(0xF2F2F2),
         connectionLine = Color(0x444444),
         excitatorySynapse = Color(0xC0392B),
         inhibitorySynapse = Color(0x2C6FB5),
         zeroWeight = Color(0xBFBFBF),
-        spiking = Color(0xF5A623),
+        spiking = Color(0xDB5A00),
         groupArrow = Color(0x2E9B3D),
-        connectorArrow = Color(0xE08600),
-        weightMatrixBoundary = Color(0xE08600),
-        receptiveFieldTrace = Color(0xE08600),
+        connectorArrow = Color(0xB86E00),
+        weightMatrixBoundary = Color(0xB86E00),
+        receptiveFieldTrace = Color(0xB86E00),
         backwardTrace = Color(0x2C6FB5),
     )
 
@@ -87,8 +90,8 @@ object NetworkTheme {
         subnetOutline = Color(0x6E7177),
         selectionHandle = Color(0x3D9BFF),
         sourceHandle = Color(0xFF5A52),
-        hotNode = Color(0xF4715E),
-        coolNode = Color(0x6FB1E6),
+        hotNode = Color(0xC74B43),
+        coolNode = Color(0x3F70B0),
         neutralMidpoint = Color(0x242629),
         connectionLine = Color(0x9A9DA3),
         excitatorySynapse = Color(0xFF6B57),

--- a/src/main/kotlin/org/simbrain/util/NetworkTheme.kt
+++ b/src/main/kotlin/org/simbrain/util/NetworkTheme.kt
@@ -38,6 +38,7 @@ object NetworkTheme {
         val subnetOutline: Color,
         val selectionHandle: Color,
         val sourceHandle: Color,
+        val marquee: Color,
         val hotNode: Color,
         val coolNode: Color,
         val neutralMidpoint: Color,
@@ -51,6 +52,7 @@ object NetworkTheme {
         val weightMatrixBoundary: Color,
         val receptiveFieldTrace: Color,
         val backwardTrace: Color,
+        val rowHighlight: Color,
     )
 
     val lightPalette = Palette(
@@ -62,8 +64,9 @@ object NetworkTheme {
         tabFillSupervised = Color(0xE2F4D8),
         tabText = Color(0x1A1A1A),
         subnetOutline = Color(0x8C8C8C),
-        selectionHandle = Color(0x0A84FF),
+        selectionHandle = Color(0x22A745),
         sourceHandle = Color(0xD32F2F),
+        marquee = Color(0xEAB308),
         hotNode = Color(0xD5584F),
         coolNode = Color(0x5082C4),
         neutralMidpoint = Color(0xF2F2F2),
@@ -77,6 +80,7 @@ object NetworkTheme {
         weightMatrixBoundary = Color(0xB86E00),
         receptiveFieldTrace = Color(0xB86E00),
         backwardTrace = Color(0x2C6FB5),
+        rowHighlight = Color(0, 200, 255, 160),
     )
 
     val darkPalette = Palette(
@@ -88,8 +92,9 @@ object NetworkTheme {
         tabFillSupervised = Color(0x2F3A2C),
         tabText = Color(0xE6E6E6),
         subnetOutline = Color(0x6E7177),
-        selectionHandle = Color(0x3D9BFF),
+        selectionHandle = Color(0x5BD96A),
         sourceHandle = Color(0xFF5A52),
+        marquee = Color(0xFFDA4D),
         hotNode = Color(0xC74B43),
         coolNode = Color(0x3F70B0),
         neutralMidpoint = Color(0x242629),
@@ -103,6 +108,7 @@ object NetworkTheme {
         weightMatrixBoundary = Color(0xF2A33C),
         receptiveFieldTrace = Color(0xF2A33C),
         backwardTrace = Color(0x6FB1E6),
+        rowHighlight = Color(90, 210, 255, 160),
     )
 
     /**

--- a/src/main/kotlin/org/simbrain/util/NetworkTheme.kt
+++ b/src/main/kotlin/org/simbrain/util/NetworkTheme.kt
@@ -1,0 +1,123 @@
+package org.simbrain.util
+
+import java.awt.Color
+import javax.swing.UIManager
+
+/**
+ * Per-mode color palette for the Piccolo2D network canvas.
+ *
+ * The rest of the app themes through FlatLaf / [Theme] (colors resolved live from `UIManager`). The
+ * network editor is a separate Piccolo2D scene whose colors come from
+ * [org.simbrain.network.gui.dialogs.NetworkPreferences] and a number of hardcoded literals, so it does
+ * not track light/dark on its own. [NetworkTheme] is the single source the canvas resolves its
+ * structural colors and its theme-aware preference defaults against (see [ThemedColorPreference]).
+ *
+ * Semantics are preserved across modes — red stays positive/excitatory and blue negative/inhibitory —
+ * only luminance is adjusted so the colors read on both a light and a dark background. The neutral
+ * activation midpoint is matched to the canvas background per mode so resting/zero values recede
+ * instead of glowing (this is consumed by the activation colormap once that step lands).
+ *
+ * [refresh] is called from [setupLookAndFeel] — the single choke point hit once at startup and again
+ * on every live theme switch — so [current] always reflects the active mode without re-running the
+ * (macOS-subprocess) [ThemeMode.resolvedDark] per paint.
+ */
+object NetworkTheme {
+
+    /** A complete canvas palette for one light/dark mode. */
+    class Palette(
+        val canvasBackground: Color,
+        val nodeOutline: Color,
+        val valueText: Color,
+        val imageBorder: Color,
+        val tabFill: Color,
+        val tabFillSupervised: Color,
+        val tabText: Color,
+        val subnetOutline: Color,
+        val selectionHandle: Color,
+        val sourceHandle: Color,
+        val hotNode: Color,
+        val coolNode: Color,
+        val neutralMidpoint: Color,
+        val connectionLine: Color,
+        val excitatorySynapse: Color,
+        val inhibitorySynapse: Color,
+        val zeroWeight: Color,
+        val spiking: Color,
+        val groupArrow: Color,
+        val connectorArrow: Color,
+        val weightMatrixBoundary: Color,
+        val receptiveFieldTrace: Color,
+        val backwardTrace: Color,
+    )
+
+    val lightPalette = Palette(
+        canvasBackground = Color(0xFAFAFA),
+        nodeOutline = Color(0x3A3A3A),
+        valueText = Color(0x1A1A1A),
+        imageBorder = Color(0x3A3A3A),
+        tabFill = Color(0xFFFDE7),
+        tabFillSupervised = Color(0xE2F4D8),
+        tabText = Color(0x1A1A1A),
+        subnetOutline = Color(0x8C8C8C),
+        selectionHandle = Color(0x0A84FF),
+        sourceHandle = Color(0xD32F2F),
+        hotNode = Color(0xB2182B),
+        coolNode = Color(0x2166AC),
+        neutralMidpoint = Color(0xF2F2F2),
+        connectionLine = Color(0x444444),
+        excitatorySynapse = Color(0xC0392B),
+        inhibitorySynapse = Color(0x2C6FB5),
+        zeroWeight = Color(0xBFBFBF),
+        spiking = Color(0xF5A623),
+        groupArrow = Color(0x2E9B3D),
+        connectorArrow = Color(0xE08600),
+        weightMatrixBoundary = Color(0xE08600),
+        receptiveFieldTrace = Color(0xE08600),
+        backwardTrace = Color(0x2C6FB5),
+    )
+
+    val darkPalette = Palette(
+        canvasBackground = Color(0x1E1F22),
+        nodeOutline = Color(0xC8CACE),
+        valueText = Color(0xE6E6E6),
+        imageBorder = Color(0xC8CACE),
+        tabFill = Color(0x3A3D42),
+        tabFillSupervised = Color(0x2F3A2C),
+        tabText = Color(0xE6E6E6),
+        subnetOutline = Color(0x6E7177),
+        selectionHandle = Color(0x3D9BFF),
+        sourceHandle = Color(0xFF5A52),
+        hotNode = Color(0xF4715E),
+        coolNode = Color(0x6FB1E6),
+        neutralMidpoint = Color(0x242629),
+        connectionLine = Color(0x9A9DA3),
+        excitatorySynapse = Color(0xFF6B57),
+        inhibitorySynapse = Color(0x5AB0F0),
+        zeroWeight = Color(0x5A5C60),
+        spiking = Color(0xFFD23F),
+        groupArrow = Color(0x57C257),
+        connectorArrow = Color(0xF2A33C),
+        weightMatrixBoundary = Color(0xF2A33C),
+        receptiveFieldTrace = Color(0xF2A33C),
+        backwardTrace = Color(0x6FB1E6),
+    )
+
+    /**
+     * Whether the canvas should use the dark palette, derived live from the active Look-and-Feel:
+     * every FlatLaf theme sets the `laf.dark` UIManager flag, so this stays correct no matter how the
+     * theme was installed ([setupLookAndFeel], a live switch, or the snapshot harness setting a FlatLaf
+     * directly). Cheap enough to read per paint.
+     */
+    val isDark: Boolean get() = UIManager.getBoolean("laf.dark")
+
+    /** The palette for the active mode. */
+    val current: Palette get() = if (isDark) darkPalette else lightPalette
+
+    /**
+     * A [ThemeColor] default for a role, taking its light value from [lightPalette] and its hand-tuned
+     * dark value from [darkPalette] (so [ThemeColor.useManualDark] is true). Used to seed the editable
+     * canvas-color preferences with both modes.
+     */
+    fun pair(select: (Palette) -> Color): ThemeColor =
+        ThemeColor(select(lightPalette), select(darkPalette), useManualDark = true)
+}

--- a/src/main/kotlin/org/simbrain/util/SimbrainPreferences.kt
+++ b/src/main/kotlin/org/simbrain/util/SimbrainPreferences.kt
@@ -92,6 +92,9 @@ sealed class Preference<T>(val default: T) {
         }
     }
 
+    /** True if the user has explicitly stored a value (rather than falling back to the default). */
+    fun isExplicitlySet(): Boolean = this::name.isInitialized && systemPreferences.get(name, null) != null
+
     open operator fun <H: PreferenceHolder> getValue(thisRef: H, property: KProperty<*>): T {
         name = property.name
         if (cachedValue == null) {
@@ -101,8 +104,16 @@ sealed class Preference<T>(val default: T) {
     }
 
     open operator fun <H: PreferenceHolder> setValue(thisRef: H, property: KProperty<*>, value: T) {
+        name = property.name
         systemPreferences.put(property.name, serialize(value))
         cachedValue = value
+    }
+
+    /** Remove any stored value for [propertyName] and drop the cache, so the next read re-resolves the default. */
+    protected fun clearStoredValue(propertyName: String) {
+        name = propertyName
+        systemPreferences.remove(propertyName)
+        cachedValue = null
     }
 
     /**
@@ -152,6 +163,31 @@ class StringPreference(defaultPath: String): Preference<String>(defaultPath) {
 class ColorPreference(defaultColor: Color): Preference<Color>(defaultColor) {
     override fun deserialize(value: String) = Color(value.toInt())
     override fun serialize(value: Color) = value.rgb.toString()
+}
+
+/**
+ * Stores a [ThemeColor] (a light + dark color pair) as a single preference, so the network canvas
+ * colors carry both modes. Serialized as `light|dark|useManualDark`.
+ *
+ * Because the property editor commits every field on OK (even unchanged ones), storing a value equal
+ * to the [default] would needlessly pin it; so only an actual deviation is stored, and returning a
+ * value to the default clears any prior customization.
+ */
+class ThemeColorPreference(default: ThemeColor): Preference<ThemeColor>(default) {
+    override fun deserialize(value: String): ThemeColor {
+        val (light, dark, manual) = value.split("|")
+        return ThemeColor(Color(light.toInt()), Color(dark.toInt()), manual.toBoolean())
+    }
+
+    override fun serialize(value: ThemeColor) = "${value.light.rgb}|${value.dark.rgb}|${value.useManualDark}"
+
+    override operator fun <H: PreferenceHolder> setValue(thisRef: H, property: KProperty<*>, value: ThemeColor) {
+        if (value == default) {
+            clearStoredValue(property.name)
+        } else {
+            super.setValue(thisRef, property, value)
+        }
+    }
 }
 
 class EnumPreference<E : Enum<E>>(defaultVal: E, private val enumClass: Class<E>): Preference<E>(defaultVal) {

--- a/src/main/kotlin/org/simbrain/util/SimbrainPreferences.kt
+++ b/src/main/kotlin/org/simbrain/util/SimbrainPreferences.kt
@@ -174,10 +174,10 @@ class ColorPreference(defaultColor: Color): Preference<Color>(defaultColor) {
  * value to the default clears any prior customization.
  */
 class ThemeColorPreference(default: ThemeColor): Preference<ThemeColor>(default) {
-    override fun deserialize(value: String): ThemeColor {
+    override fun deserialize(value: String): ThemeColor = runCatching {
         val (light, dark, manual) = value.split("|")
-        return ThemeColor(Color(light.toInt()), Color(dark.toInt()), manual.toBoolean())
-    }
+        ThemeColor(Color(light.toInt(), true), Color(dark.toInt(), true), manual.toBoolean())
+    }.getOrDefault(default)
 
     override fun serialize(value: ThemeColor) = "${value.light.rgb}|${value.dark.rgb}|${value.useManualDark}"
 

--- a/src/main/kotlin/org/simbrain/util/ThemeColor.kt
+++ b/src/main/kotlin/org/simbrain/util/ThemeColor.kt
@@ -1,0 +1,97 @@
+package org.simbrain.util
+
+import java.awt.Color
+import kotlin.math.roundToInt
+
+/**
+ * A theme-aware color: a [light] color, a [dark] color, and a [useManualDark] flag. [resolve] returns
+ * the right color for the active mode — [light] in light mode; in dark mode the explicit [dark] when
+ * [useManualDark], otherwise a value [inferred][inferDark] from [light].
+ *
+ * Used for the user-editable network canvas colors (see [org.simbrain.network.gui.dialogs.NetworkPreferences]
+ * and `ThemeColorPreference`), so a single preference carries both light and dark variants. Edited via
+ * the compact two-swatch widget in the property editor.
+ */
+class ThemeColor(
+    val light: Color = Color.GRAY,
+    val dark: Color = inferDark(light),
+    val useManualDark: Boolean = false,
+) {
+    fun resolve(isDark: Boolean): Color = when {
+        !isDark -> light
+        useManualDark -> dark
+        else -> inferDark(light)
+    }
+
+    /** The color for the currently active [NetworkTheme] mode. */
+    val resolved: Color get() = resolve(NetworkTheme.isDark)
+
+    fun copy(light: Color = this.light, dark: Color = this.dark, useManualDark: Boolean = this.useManualDark) =
+        ThemeColor(light, dark, useManualDark)
+
+    override fun equals(other: Any?) = other is ThemeColor &&
+            other.light == light && other.dark == dark && other.useManualDark == useManualDark
+
+    override fun hashCode(): Int {
+        var result = light.hashCode()
+        result = 31 * result + dark.hashCode()
+        result = 31 * result + useManualDark.hashCode()
+        return result
+    }
+
+    override fun toString() = "ThemeColor(light=$light, dark=$dark, useManualDark=$useManualDark)"
+}
+
+/**
+ * Infer a dark-mode variant of a light-mode color by inverting HSL lightness while keeping hue and
+ * saturation, clamped so the result never reaches pure black or white. This lightens dark colors and
+ * darkens light ones — the right behavior for canvas elements that must read on the opposite
+ * background — and approximates the hand-tuned dark palette (e.g. a light red maps to a lighter red).
+ */
+fun inferDark(light: Color): Color {
+    val (h, s, l) = light.toHSL()
+    val invertedL = (1f - l).coerceIn(0.16f, 0.92f)
+    return hslColor(h, s, invertedL)
+}
+
+/** Convert to HSL as (hue, saturation, lightness), each in 0..1. */
+fun Color.toHSL(): Triple<Float, Float, Float> {
+    val r = red / 255f
+    val g = green / 255f
+    val b = blue / 255f
+    val max = maxOf(r, g, b)
+    val min = minOf(r, g, b)
+    val l = (max + min) / 2f
+    if (max == min) return Triple(0f, 0f, l)
+    val d = max - min
+    val s = if (l > 0.5f) d / (2f - max - min) else d / (max + min)
+    val h = when (max) {
+        r -> (g - b) / d + (if (g < b) 6f else 0f)
+        g -> (b - r) / d + 2f
+        else -> (r - g) / d + 4f
+    } / 6f
+    return Triple(h, s, l)
+}
+
+/** Build an opaque color from HSL components, each in 0..1. */
+fun hslColor(h: Float, s: Float, l: Float): Color {
+    if (s == 0f) {
+        val v = (l * 255f).roundToInt().coerceIn(0, 255)
+        return Color(v, v, v)
+    }
+    val q = if (l < 0.5f) l * (1f + s) else l + s - l * s
+    val p = 2f * l - q
+    fun hueToChannel(t0: Float): Float {
+        var t = t0
+        if (t < 0f) t += 1f
+        if (t > 1f) t -= 1f
+        return when {
+            t < 1f / 6f -> p + (q - p) * 6f * t
+            t < 1f / 2f -> q
+            t < 2f / 3f -> p + (q - p) * (2f / 3f - t) * 6f
+            else -> p
+        }
+    }
+    fun channel(v: Float) = (v * 255f).roundToInt().coerceIn(0, 255)
+    return Color(channel(hueToChannel(h + 1f / 3f)), channel(hueToChannel(h)), channel(hueToChannel(h - 1f / 3f)))
+}

--- a/src/main/kotlin/org/simbrain/util/piccolo/PiccoloUtils.kt
+++ b/src/main/kotlin/org/simbrain/util/piccolo/PiccoloUtils.kt
@@ -10,6 +10,7 @@ import org.piccolo2d.nodes.PPath
 import org.piccolo2d.util.PAffineTransform
 import org.piccolo2d.util.PBounds
 import org.simbrain.network.gui.nodes.ScreenElement
+import org.simbrain.util.NetworkTheme
 import org.simbrain.util.component1
 import org.simbrain.util.component2
 import org.simbrain.util.minus
@@ -43,12 +44,12 @@ val PInputEvent.isDoubleClick
 fun Collection<PNode>.unionOfGlobalFullBounds() = map { it.globalFullBounds }.fold(PBounds()) { acc, b -> acc.add(b); acc }
 
 /**
- * Add a black border around a PImage. Must be called after the image's bounds have been set.
+ * Add a themed border around a PImage. Must be called after the image's bounds have been set.
  */
 fun PImage.addBorder(strokeWidth: Float = 1f): PNode {
     val (x, y, w, h) = bounds
     val box = PPath.createRectangle(x, y, w, h)
-    box.strokePaint = Color.BLACK
+    box.strokePaint = NetworkTheme.current.imageBorder
     box.stroke = BasicStroke(strokeWidth)
     box.paint = null
     addChild(box)

--- a/src/main/kotlin/org/simbrain/util/propertyeditor/AnnotatedPropertyEditor.kt
+++ b/src/main/kotlin/org/simbrain/util/propertyeditor/AnnotatedPropertyEditor.kt
@@ -1,6 +1,7 @@
 package org.simbrain.util.propertyeditor
 
 import org.simbrain.util.LabelledItemPanel
+import org.simbrain.util.ThemeColor
 import org.simbrain.util.UserParameter
 import org.simbrain.util.invokeLegacySetter
 import org.simbrain.util.swingInvokeLater
@@ -237,6 +238,12 @@ class AnnotatedPropertyEditor<O : EditableObject> @JvmOverloads constructor(
             is Color -> ColorWidget(
                 this@AnnotatedPropertyEditor,
                 userParameter as GuiEditable<O, Color>,
+                isConsistent
+            ) as ParameterWidget<O, T>
+
+            is ThemeColor -> ThemeColorWidget(
+                this@AnnotatedPropertyEditor,
+                userParameter as GuiEditable<O, ThemeColor>,
                 isConsistent
             ) as ParameterWidget<O, T>
 

--- a/src/main/kotlin/org/simbrain/util/propertyeditor/GuiEditable.kt
+++ b/src/main/kotlin/org/simbrain/util/propertyeditor/GuiEditable.kt
@@ -5,6 +5,7 @@ import org.simbrain.util.SimbrainConstants.NULL_STRING
 import org.simbrain.util.table.*
 import org.simbrain.util.widgets.ChoicesWithNull
 import org.simbrain.util.widgets.ColorSelector
+import org.simbrain.util.widgets.ThemeColorSelector
 import org.simbrain.util.widgets.YesNoNull
 import org.simbrain.workspace.WorkspacePreferences
 import smile.math.matrix.Matrix
@@ -756,6 +757,38 @@ class ColorWidget<O : EditableObject>(
     }
 
     override val value: Color
+        get() = widget.value
+
+    override fun refresh(property: KProperty<*>) {
+        parameter.update(UpdateFunctionContext(
+            editor,
+            parameter,
+            property,
+            enableWidgetProvider = { enabled ->
+                widget.isEnabled = enabled
+            },
+            widgetVisibilityProvider = { visible ->
+                widget.isVisible = visible
+            }
+        ))
+    }
+}
+
+class ThemeColorWidget<O : EditableObject>(
+    val editor: AnnotatedPropertyEditor<O>,
+    parameter: GuiEditable<O, ThemeColor>,
+    isConsistent: Boolean
+) : ParameterWidget<O, ThemeColor>(parameter, isConsistent) {
+
+    override val widget by lazy {
+        ThemeColorSelector().also {
+            if (isConsistent) {
+                it.value = parameter.value
+            }
+        }
+    }
+
+    override val value: ThemeColor
         get() = widget.value
 
     override fun refresh(property: KProperty<*>) {

--- a/src/main/kotlin/org/simbrain/util/widgets/BezierArrow.kt
+++ b/src/main/kotlin/org/simbrain/util/widgets/BezierArrow.kt
@@ -104,12 +104,20 @@ class BezierArrow(template: BezierArrowTemplate) : PNode() {
     }
 
     /**
+     * Recolor the arrow to the given color. The arrowTip paint is updated immediately; the curve
+     * strokePaint updates on the next [layout] call.
+     */
+    fun updateColor(color: Color) {
+        this.color = color
+        arrowTip.paint = color
+    }
+
+    /**
      * Update the arrow color from the current [NetworkPreferences.connectorArrowColor].
      * The arrowTip paint is updated immediately; the curve strokePaint updates on the next [layout] call.
      */
     fun updateColorFromPreferences() {
-        color = NetworkPreferences.connectorArrowColor
-        arrowTip.paint = color
+        updateColor(NetworkPreferences.connectorArrowColor)
     }
 
     /**

--- a/src/main/kotlin/org/simbrain/util/widgets/BezierArrow.kt
+++ b/src/main/kotlin/org/simbrain/util/widgets/BezierArrow.kt
@@ -1,12 +1,13 @@
 package org.simbrain.util.widgets
 
 import org.piccolo2d.PNode
-import org.piccolo2d.nodes.PArea
 import org.piccolo2d.nodes.PPath
 import org.simbrain.network.gui.dialogs.NetworkPreferences
 import org.simbrain.util.*
 import java.awt.BasicStroke
 import java.awt.Color
+import java.awt.geom.AffineTransform
+import java.awt.geom.Area
 import java.awt.geom.CubicCurve2D
 import java.awt.geom.Line2D
 
@@ -35,16 +36,17 @@ class BezierArrow(template: BezierArrowTemplate) : PNode() {
     private val updateEvent = template.updateEvent
 
     /**
-     * The triangle at the tip of the arrow. This triangle is constructed only once, and during [layout] the this
-     * triangle will be placed onto the correct location
+     * The triangle at the tip of the arrow. This shape is constructed only once, and during [layout] it is
+     * transformed onto the correct location and unioned with the stroked curve.
      */
-    private val arrowTip = listOf(point(0.0, -sin60deg), point(0.5, 0.0), point(-0.5, 0.0))
+    private val arrowTipShape = listOf(point(0.0, -sin60deg), point(0.5, 0.0), point(-0.5, 0.0))
             .map { it * (thickness * 2.0) }.toPolygon()
-            .let { polygon -> PArea(polygon, null) }
-            .apply {
-                paint = color
-                transparency = 0.5f
-            }
+
+    /**
+     * The arrow as currently rendered: the stroked curve and the tip triangle unioned into a single
+     * translucent shape, so their overlap does not double-blend into seams.
+     */
+    private var arrowView: PPath? = null
 
     /**
      * Update the shape of the arrow base on the outlines of source and target.
@@ -71,15 +73,7 @@ class BezierArrow(template: BezierArrowTemplate) : PNode() {
                     }
                 }.also { if (it == null) updateEvent(null) } ?: return
 
-        // 2. put the arrow tip at the right location and orient it at the right angle
-        arrowTip.getTransformReference(true).apply {
-            setToTranslation(targetSide.headOffset.x, targetSide.headOffset.y)
-            val theta = targetSide.normalTheta
-            rotate(theta)
-        }
-        arrowTip.invalidateFullBounds();
-
-        // 3. compute the curve
+        // 2. compute the curve
         val curveModel = cubicBezier(
                 sourceSide.tailOffset,
                 sourceSide.tailOffset + deltaVector.abs * sourceSide.unitNormal * 0.5,
@@ -87,34 +81,36 @@ class BezierArrow(template: BezierArrowTemplate) : PNode() {
                 targetSide.headOffset
         )
 
-        // 4. create the curve PNode
-        val curveView = PPath.Double(curveModel, BasicStroke(thickness, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER)).apply {
-            paint = null
-            strokePaint = color
-            transparency = 0.5f
+        // 3. transform the tip onto the head location and union it with the stroked curve
+        val tipTransform = AffineTransform().apply {
+            translate(targetSide.headOffset.x, targetSide.headOffset.y)
+            rotate(targetSide.normalTheta)
+        }
+        val arrowShape = Area(BasicStroke(thickness, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER).createStrokedShape(curveModel)).apply {
+            add(Area(tipTransform.createTransformedShape(arrowTipShape)))
         }
 
-        // 5. add shape to node
-        addChild(curveView)
-        addChild(arrowTip)
+        // 4. create the arrow PNode
+        arrowView = PPath.Double(arrowShape, null).apply {
+            paint = color
+            transparency = 0.5f
+        }.also { addChild(it) }
 
-        // 6. call back
+        // 5. call back
         updateEvent(curveModel)
 
     }
 
     /**
-     * Recolor the arrow to the given color. The arrowTip paint is updated immediately; the curve
-     * strokePaint updates on the next [layout] call.
+     * Recolor the arrow to the given color.
      */
     fun updateColor(color: Color) {
         this.color = color
-        arrowTip.paint = color
+        arrowView?.paint = color
     }
 
     /**
      * Update the arrow color from the current [NetworkPreferences.connectorArrowColor].
-     * The arrowTip paint is updated immediately; the curve strokePaint updates on the next [layout] call.
      */
     fun updateColorFromPreferences() {
         updateColor(NetworkPreferences.connectorArrowColor)

--- a/src/main/kotlin/org/simbrain/util/widgets/RecurrentArrow.kt
+++ b/src/main/kotlin/org/simbrain/util/widgets/RecurrentArrow.kt
@@ -49,13 +49,17 @@ class RecurrentArrow(color: Color) : PNode() {
             transparency = 0.5f
         }.also { addChild(it) }
 
+    /** Recolor the arc and tip to the given color. */
+    fun updateColor(color: Color) {
+        arrowTip.paint = color
+        arc.strokePaint = color
+    }
+
     /**
      * Update the arrow color from the current [NetworkPreferences.connectorArrowColor][org.simbrain.network.gui.dialogs.NetworkPreferences.connectorArrowColor].
      */
     fun updateColorFromPreferences() {
-        val c = NetworkPreferences.connectorArrowColor
-        arrowTip.paint = c
-        arc.strokePaint = c
+        updateColor(NetworkPreferences.connectorArrowColor)
     }
 
     /**

--- a/src/main/kotlin/org/simbrain/util/widgets/RecurrentArrow.kt
+++ b/src/main/kotlin/org/simbrain/util/widgets/RecurrentArrow.kt
@@ -1,13 +1,14 @@
 package org.simbrain.util.widgets
 
 import org.piccolo2d.PNode
-import org.piccolo2d.nodes.PArea
 import org.piccolo2d.nodes.PPath
 import org.simbrain.network.gui.dialogs.NetworkPreferences
 import org.simbrain.util.*
 import java.awt.BasicStroke
 import java.awt.Color
+import java.awt.geom.AffineTransform
 import java.awt.geom.Arc2D
+import java.awt.geom.Area
 import java.awt.geom.Point2D
 import kotlin.math.cos
 import kotlin.math.sin
@@ -24,35 +25,32 @@ class RecurrentArrow(color: Color) : PNode() {
     private val endDeg = 320.0
 
     /**
-     * The triangle at the tip of the arrow. This triangle is constructed only once, and during [layout] this
-     * triangle will be placed onto the correct location
+     * The stroked arc and the tip triangle unioned into a single translucent shape, so their
+     * overlap does not double-blend into seams.
      */
-    private val arrowTip = listOf(point(-1, 0), point(1, 0), point(0, -1))
-            .map { it * 30.0 }
-            .toPolygon()
-            .let { polygon -> PArea(polygon, null) }
-            .apply {
-                paint = color
-                val arrowTipRadian = endDeg.toRadian()
-                rotate(-arrowTipRadian)
-                offset(cos(arrowTipRadian) * radius, -sin(arrowTipRadian) * radius)
-                transparency = 0.5f
-                this@RecurrentArrow.addChild(this)
-            }
-
-    private val arc = PPath.createArc(-radius, -radius, 2 * radius, 2 * radius, startDeg,
-        endDeg - startDeg, Arc2D.OPEN)
-        .apply {
-            paint = null
-            stroke = BasicStroke(20.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER)
-            strokePaint = color
+    private val arrowView = run {
+        val arc = Arc2D.Double(-radius, -radius, 2 * radius, 2 * radius, startDeg, endDeg - startDeg, Arc2D.OPEN)
+        val arrowTipRadian = endDeg.toRadian()
+        val tipTransform = AffineTransform().apply {
+            translate(cos(arrowTipRadian) * radius, -sin(arrowTipRadian) * radius)
+            rotate(-arrowTipRadian)
+        }
+        val arrowTipShape = listOf(point(-1, 0), point(1, 0), point(0, -1))
+                .map { it * 30.0 }
+                .toPolygon()
+        val arrowShape = Area(BasicStroke(20.0f, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER).createStrokedShape(arc)).apply {
+            add(Area(tipTransform.createTransformedShape(arrowTipShape)))
+        }
+        PPath.Double(arrowShape, null).apply {
+            paint = color
             transparency = 0.5f
-        }.also { addChild(it) }
+            this@RecurrentArrow.addChild(this)
+        }
+    }
 
-    /** Recolor the arc and tip to the given color. */
+    /** Recolor the arrow to the given color. */
     fun updateColor(color: Color) {
-        arrowTip.paint = color
-        arc.strokePaint = color
+        arrowView.paint = color
     }
 
     /**

--- a/src/main/kotlin/org/simbrain/util/widgets/SimbrainTextArea.kt
+++ b/src/main/kotlin/org/simbrain/util/widgets/SimbrainTextArea.kt
@@ -1,9 +1,31 @@
 package org.simbrain.util.widgets
 
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
+import org.fife.ui.rsyntaxtextarea.Theme
 import org.simbrain.util.CmdOrCtrl
 import org.simbrain.util.createAction
 import javax.swing.JFrame
+import javax.swing.UIManager
+
+/**
+ * [RSyntaxTextArea] does its own theming (via bundled XML themes) and does not follow FlatLaf, so it
+ * stays light in dark mode unless it is explicitly re-themed. Loads the matching bundled RSyntax theme
+ * for the active Look-and-Feel, preserving the current font. Called at construction and re-invoked on a
+ * live theme switch by [org.simbrain.workspace.gui.SimbrainDesktop.refreshThemedChrome].
+ */
+fun RSyntaxTextArea.applyLafSyntaxTheme() {
+    val themePath = if (UIManager.getBoolean("laf.dark")) {
+        "/org/fife/ui/rsyntaxtextarea/themes/dark.xml"
+    } else {
+        "/org/fife/ui/rsyntaxtextarea/themes/default.xml"
+    }
+    try {
+        Theme::class.java.getResourceAsStream(themePath)?.use { Theme.load(it, font).apply(this) }
+    } catch (e: Exception) {
+        // Keep RSyntaxTextArea defaults if the bundled theme cannot be loaded.
+    }
+    currentLineHighlightColor = background
+}
 
 class SimbrainTextArea : RSyntaxTextArea() {
 
@@ -11,7 +33,7 @@ class SimbrainTextArea : RSyntaxTextArea() {
     var lastReplacedString: String? = null
 
     init {
-        currentLineHighlightColor = background
+        applyLafSyntaxTheme()
         createAction(
             name = "Find / Replace...",
             description = "Find and replace text...",

--- a/src/main/kotlin/org/simbrain/util/widgets/ThemeColorSelector.kt
+++ b/src/main/kotlin/org/simbrain/util/widgets/ThemeColorSelector.kt
@@ -1,0 +1,87 @@
+package org.simbrain.util.widgets
+
+import org.simbrain.util.Theme
+import org.simbrain.util.ThemeColor
+import org.simbrain.util.inferDark
+import java.awt.Color
+import java.awt.Cursor
+import java.awt.Dimension
+import java.awt.FlowLayout
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import javax.swing.BorderFactory
+import javax.swing.JCheckBox
+import javax.swing.JColorChooser
+import javax.swing.JLabel
+import javax.swing.JPanel
+
+/**
+ * Compact editor for a [ThemeColor]: a light swatch, a dark swatch, and an "auto" checkbox that derives
+ * the dark color from the light one. While auto is on, the dark swatch is disabled and previews the
+ * inferred color; turning auto off lets the dark color be picked directly.
+ */
+class ThemeColorSelector : JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)) {
+
+    private var lightColor: Color = Color.GRAY
+    private var manualDarkColor: Color = Color.DARK_GRAY
+    private var useManualDark: Boolean = false
+
+    private val lightSwatch = swatch { chooseColor("Choose Light Color", lightColor) { lightColor = it } }
+    private val darkSwatch = swatch { chooseColor("Choose Dark Color", effectiveDark()) { manualDarkColor = it } }
+
+    private val autoCheckBox = JCheckBox("auto").apply {
+        toolTipText = "Derive the dark-mode color from the light color"
+        addActionListener {
+            useManualDark = !isSelected
+            refreshSwatches()
+        }
+    }
+
+    init {
+        add(JLabel("Light"))
+        add(lightSwatch)
+        add(JLabel("Dark"))
+        add(darkSwatch)
+        add(autoCheckBox)
+        refreshSwatches()
+    }
+
+    private fun swatch(onClick: () -> Unit) = JPanel().apply {
+        preferredSize = Dimension(26, 16)
+        border = BorderFactory.createLineBorder(Theme.divider)
+        cursor = Cursor.getPredefinedCursor(Cursor.HAND_CURSOR)
+        addMouseListener(object : MouseAdapter() {
+            override fun mouseClicked(e: MouseEvent) {
+                if (isEnabled) onClick()
+            }
+        })
+    }
+
+    private fun chooseColor(title: String, initial: Color, onChosen: (Color) -> Unit) {
+        JColorChooser.showDialog(this, title, initial)?.let {
+            onChosen(it)
+            refreshSwatches()
+        }
+    }
+
+    private fun effectiveDark(): Color = if (useManualDark) manualDarkColor else inferDark(lightColor)
+
+    private fun refreshSwatches() {
+        lightSwatch.background = lightColor
+        darkSwatch.background = effectiveDark()
+        darkSwatch.isEnabled = useManualDark
+        darkSwatch.cursor = Cursor.getPredefinedCursor(
+            if (useManualDark) Cursor.HAND_CURSOR else Cursor.DEFAULT_CURSOR
+        )
+        autoCheckBox.isSelected = !useManualDark
+    }
+
+    var value: ThemeColor
+        get() = ThemeColor(lightColor, effectiveDark(), useManualDark)
+        set(themeColor) {
+            lightColor = themeColor.light
+            manualDarkColor = themeColor.dark
+            useManualDark = themeColor.useManualDark
+            refreshSwatches()
+        }
+}

--- a/src/main/kotlin/org/simbrain/util/widgets/ThemeColorSelector.kt
+++ b/src/main/kotlin/org/simbrain/util/widgets/ThemeColorSelector.kt
@@ -77,7 +77,7 @@ class ThemeColorSelector : JPanel(FlowLayout(FlowLayout.LEFT, 4, 0)) {
     }
 
     var value: ThemeColor
-        get() = ThemeColor(lightColor, effectiveDark(), useManualDark)
+        get() = ThemeColor(lightColor, manualDarkColor, useManualDark)
         set(themeColor) {
             lightColor = themeColor.light
             manualDarkColor = themeColor.dark

--- a/src/main/kotlin/org/simbrain/workspace/gui/SimbrainDesktop.kt
+++ b/src/main/kotlin/org/simbrain/workspace/gui/SimbrainDesktop.kt
@@ -14,6 +14,7 @@ import org.pmw.tinylog.Logger
 import org.simbrain.console.ConsoleDesktopComponent
 import org.simbrain.custom_sims.simulations
 import org.simbrain.docviewer.DocViewerViewPanel
+import org.simbrain.network.gui.NetworkPanel
 import org.simbrain.util.*
 import org.simbrain.util.genericframe.GenericFrame
 import org.simbrain.util.genericframe.GenericJFrame
@@ -594,6 +595,7 @@ object SimbrainDesktop {
             when (c) {
                 is ChartPanel -> c.chart?.let { it.applySimbrainChartTheme(); it.fireChartChanged() }
                 is JTable -> c.gridColor = Theme.divider
+                is NetworkPanel -> c.preferenceLoader()
             }
             if (c is Container) c.components.forEach(::walk)
         }

--- a/src/main/kotlin/org/simbrain/workspace/gui/SimbrainDesktop.kt
+++ b/src/main/kotlin/org/simbrain/workspace/gui/SimbrainDesktop.kt
@@ -3,8 +3,10 @@ package org.simbrain.workspace.gui
 import bsh.Interpreter
 import bsh.util.JConsole
 import com.formdev.flatlaf.FlatLaf
+import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea
 import org.jfree.chart.ChartPanel
 import org.simbrain.plot.applySimbrainChartTheme
+import org.simbrain.util.widgets.applyLafSyntaxTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -596,6 +598,7 @@ object SimbrainDesktop {
                 is ChartPanel -> c.chart?.let { it.applySimbrainChartTheme(); it.fireChartChanged() }
                 is JTable -> c.gridColor = Theme.divider
                 is NetworkPanel -> c.preferenceLoader()
+                is RSyntaxTextArea -> c.applyLafSyntaxTheme()
             }
             if (c is Container) c.components.forEach(::walk)
         }

--- a/src/snapshots/kotlin/org/simbrain/util/uisnapshot/KitchenSinkSnapshot.kt
+++ b/src/snapshots/kotlin/org/simbrain/util/uisnapshot/KitchenSinkSnapshot.kt
@@ -1,0 +1,294 @@
+package org.simbrain.util.uisnapshot
+
+import com.formdev.flatlaf.FlatDarkLaf
+import com.formdev.flatlaf.FlatLightLaf
+import kotlinx.coroutines.runBlocking
+import org.simbrain.network.NetworkComponent
+import org.simbrain.network.core.ActivationSequence
+import org.simbrain.network.core.ConvolutionConnector
+import org.simbrain.network.core.FlattenConnector
+import org.simbrain.network.core.Network
+import org.simbrain.network.core.NetworkTextObject
+import org.simbrain.network.core.Neuron
+import org.simbrain.network.core.NeuronArray
+import org.simbrain.network.core.NeuronCollection
+import org.simbrain.network.core.Padding
+import org.simbrain.network.core.SynapseGroup
+import org.simbrain.network.core.TensorActivation
+import org.simbrain.network.core.TensorLayer
+import org.simbrain.network.core.TensorShape
+import org.simbrain.network.core.TransformerBlock
+import org.simbrain.network.core.WeightMatrix
+import org.simbrain.network.gui.NetworkPanel
+import org.simbrain.network.smile.ClassifierNetwork
+import org.simbrain.network.smile.classifiers.SVMClassifier
+import org.simbrain.network.subnetworks.Hopfield
+import org.simbrain.network.subnetworks.SRNNetwork
+import org.simbrain.network.trainers.ClassificationDatasetEncoding
+import org.simbrain.network.trainers.createClassificationDataset
+import org.simbrain.util.point
+import smile.math.matrix.Matrix
+import java.awt.Component
+import java.awt.Dimension
+import javax.swing.JDialog
+import javax.swing.SwingUtilities
+
+/**
+ * One of every model node (in the view modes worth checking) on a single network canvas, so the
+ * harness can render it light + dark and spot non-themed / white surfaces. Layout is on a wide grid
+ * with generous spacing so nothing overlaps. A few models get deterministic non-zero activations /
+ * weights so hot/cool colormap colors show (no Math.random — the scene must be reproducible).
+ */
+class KitchenSinkSnapshot : UiSnapshotDef {
+    override val name = "kitchen_sink"
+
+    /** Spread of deterministic values in [-1, 1] for an array of the given size. */
+    private fun spread(size: Int): DoubleArray =
+        DoubleArray(size) { (it - (size - 1) / 2.0) / ((size - 1) / 2.0).coerceAtLeast(1.0) }
+
+    override fun build(): Component {
+        // Capture the harness-selected theme before any app code reinstalls a stale look-and-feel
+        // mid-build; we re-assert it (then run the recolor hook) at the end.
+        val harnessDark = javax.swing.UIManager.getBoolean("laf.dark")
+        val network = Network()
+        val component = NetworkComponent("snapshot", network)
+        val panel = NetworkPanel(component).apply { preferredSize = Dimension(1400, 1000) }
+
+        runBlocking {
+
+            // Row 1: neuron arrays in every image/circle view mode.
+
+            // NeuronArray, line/flat horizontal image.
+            val naLineH = NeuronArray(25).apply {
+                label = "Array line/flat (h)"
+                gridMode = false
+                circleMode = false
+                verticalLayout = false
+                setActivations(spread(25))
+            }
+            network.addNetworkModel(naLineH, usePlacementManager = false)
+            naLineH.location = point(-600.0, -500.0)
+
+            // NeuronArray, line/flat vertical image.
+            val naLineV = NeuronArray(25).apply {
+                label = "Array line/flat (v)"
+                gridMode = false
+                circleMode = false
+                verticalLayout = true
+                setActivations(spread(25))
+            }
+            network.addNetworkModel(naLineV, usePlacementManager = false)
+            naLineV.location = point(-300.0, -500.0)
+
+            // NeuronArray, grid (square image) mode.
+            val naGrid = NeuronArray(25).apply {
+                label = "Array grid"
+                gridMode = true
+                setActivations(spread(25))
+            }
+            network.addNetworkModel(naGrid, usePlacementManager = false)
+            naGrid.location = point(0.0, -500.0)
+
+            // NeuronArray, grid image with bias image shown.
+            val naBias = NeuronArray(25).apply {
+                label = "Array + bias"
+                gridMode = true
+                isShowBias = true
+                setActivations(spread(25))
+            }
+            network.addNetworkModel(naBias, usePlacementManager = false)
+            naBias.location = point(300.0, -500.0)
+
+            // NeuronArray, CIRCLE mode (grid of NeuronCircleNodes).
+            val naCircle = NeuronArray(25).apply {
+                label = "Array circle"
+                circleMode = true
+                gridMode = true
+                setActivations(spread(25))
+            }
+            network.addNetworkModel(naCircle, usePlacementManager = false)
+            naCircle.location = point(600.0, -500.0)
+
+            // Row 2: weight matrix between two arrays.
+            val wmSrc = NeuronArray(25).apply {
+                label = "WM source"
+                gridMode = true
+                setActivations(spread(25))
+            }
+            val wmTgt = NeuronArray(16).apply {
+                label = "WM target"
+                gridMode = true
+            }
+            network.addNetworkModel(wmSrc, usePlacementManager = false)
+            network.addNetworkModel(wmTgt, usePlacementManager = false)
+            wmSrc.location = point(-600.0, -200.0)
+            wmTgt.location = point(-200.0, -200.0)
+            val wm = WeightMatrix(wmSrc, wmTgt)
+            network.addNetworkModel(wm, usePlacementManager = false)
+            // Deterministic spread of +/- weights so neg/mid/pos colors show.
+            val wmData = DoubleArray(25 * 16) { ((it % 7) - 3) / 3.0 }
+            wm.setWeights(wmData)
+
+            // Row 2 right: free-standing text node.
+            val textObject = NetworkTextObject("Free text node").apply {
+                fontSize = 18
+                isBold = true
+            }
+            textObject.location = point(150.0, -200.0)
+            network.addNetworkModel(textObject, usePlacementManager = false)
+
+            // Row 3: NeuronCollection (a few neurons + green tab + outline).
+            val nc1 = Neuron().apply { location = point(-600.0, 100.0) }
+            val nc2 = Neuron().apply { location = point(-560.0, 100.0) }
+            val nc3 = Neuron().apply { location = point(-520.0, 100.0) }
+            network.addNetworkModel(nc1, usePlacementManager = false)
+            network.addNetworkModel(nc2, usePlacementManager = false)
+            network.addNetworkModel(nc3, usePlacementManager = false)
+            val nc = NeuronCollection(listOf(nc1, nc2, nc3)).apply { label = "Collection" }
+            network.addNetworkModel(nc, usePlacementManager = false)
+
+            // Row 3 middle: SynapseGroup in directed (collapsed green arrow) mode.
+            val sgSrc = listOf(
+                Neuron().apply { location = point(-260.0, 60.0) },
+                Neuron().apply { location = point(-220.0, 60.0) },
+                Neuron().apply { location = point(-240.0, 100.0) }
+            )
+            sgSrc.forEach { network.addNetworkModel(it, usePlacementManager = false) }
+            val sgSrcGroup = NeuronCollection(sgSrc).apply { label = "SG src" }
+            network.addNetworkModel(sgSrcGroup, usePlacementManager = false)
+            val sgTgt = listOf(
+                Neuron().apply { location = point(60.0, 60.0) },
+                Neuron().apply { location = point(100.0, 60.0) },
+                Neuron().apply { location = point(80.0, 100.0) }
+            )
+            sgTgt.forEach { network.addNetworkModel(it, usePlacementManager = false) }
+            val sgTgtGroup = NeuronCollection(sgTgt).apply { label = "SG tgt" }
+            network.addNetworkModel(sgTgtGroup, usePlacementManager = false)
+            val sg = SynapseGroup(sgSrcGroup, sgTgtGroup).apply {
+                autoVisibility = false   // stop the threshold from re-expanding it
+                displaySynapses = false  // -> directed green arrow
+            }
+            network.addNetworkModel(sg, usePlacementManager = false)
+
+            // Row 4: SRN subnetwork (Outline + tab + 4 internal NeuronArray layers + weight matrices).
+            val srn = SRNNetwork(
+                numInputNodes = 5,
+                numHiddenNodes = 5,
+                numOutputNodes = 5,
+                initialPosition = point(0, 0)
+            )
+            network.addNetworkModel(srn, usePlacementManager = false)
+            srn.location = point(-600.0, 350.0)
+
+            // Row 4 right: SmileClassifier (Outline + tab + 2 green-tab NeuronCollections + bezier arrow).
+            val svm = SVMClassifier(
+                createClassificationDataset(
+                    inputs = mutableListOf(
+                        mutableListOf(0.0, 0.0, 0.0),
+                        mutableListOf(1.0, 0.0, 0.0),
+                        mutableListOf(0.0, 1.0, 0.0),
+                        mutableListOf(1.0, 1.0, 0.0)
+                    ),
+                    targets = mutableListOf(-1, 1, 1, -1),
+                    encoding = ClassificationDatasetEncoding.Bipolar
+                ),
+                1.0
+            )
+            val classifier = ClassifierNetwork(svm)
+            network.addNetworkModel(classifier, usePlacementManager = false)
+            classifier.location = point(-150.0, 350.0)
+
+            // Row 4 far right: Hopfield subnetwork (carries an InfoText status readout under it).
+            val hopfield = Hopfield(8)
+            network.addNetworkModel(hopfield, usePlacementManager = false)
+            hopfield.location = point(300.0, 350.0)
+            hopfield.updateStateInfoText()
+
+            // Row 5: TensorLayer (8x8x3) — thumbnail strip / single-channel / RGB views all exercisable.
+            val tensor = TensorLayer(TensorShape(8, 8, 3)).apply {
+                label = "Tensor 8x8x3"
+                thumbnailStripMode = true
+            }
+            network.addNetworkModel(tensor, usePlacementManager = false)
+            tensor.location = point(-600.0, 650.0)
+            // Deterministic spread across the 192-element tensor so the colormap shows hot/cool.
+            tensor.activations = spread(tensor.shape.size)
+
+            // Row 5 middle: ConvolutionConnector (single-kernel heatmap + kernel grid) via two tensors.
+            val convIn = TensorLayer(TensorShape(8, 8, 3)).apply {
+                label = "Conv in 8x8x3"
+                activations = spread(8 * 8 * 3)
+            }
+            val convOut = TensorLayer(convIn.shape.convOutputShape(3, 1, Padding.SAME, 4)).apply {
+                label = "Conv out 8x8x4"
+                activationFunction = TensorActivation.RELU
+            }
+            network.addNetworkModel(convIn, usePlacementManager = false)
+            network.addNetworkModel(convOut, usePlacementManager = false)
+            convIn.location = point(-250.0, 650.0)
+            convOut.location = point(100.0, 650.0)
+            val conv = ConvolutionConnector(
+                convIn, convOut,
+                kernelSize = 3, numFilters = 4, stride = 1, padding = Padding.SAME
+            ).apply { label = "Convolution" }
+            network.addNetworkModel(conv, usePlacementManager = false)
+            // Deterministic visible kernel weights.
+            val kernelData = conv.kernels
+            for (i in kernelData.indices) kernelData[i] = ((i % 5) - 2) / 2.0
+            conv.kernels = kernelData
+
+            // Row 5 right: FlattenConnector (plain bezier arrow Tensor -> NeuronArray).
+            val poolOut = TensorLayer(TensorShape(4, 4, 4)).apply {
+                label = "Pool 4x4x4"
+                activations = spread(4 * 4 * 4)
+            }
+            val flat = NeuronArray(4 * 4 * 4).apply {
+                label = "Flattened (64)"
+                gridMode = true
+            }
+            network.addNetworkModel(poolOut, usePlacementManager = false)
+            network.addNetworkModel(flat, usePlacementManager = false)
+            poolOut.location = point(450.0, 650.0)
+            flat.location = point(750.0, 650.0)
+            val flatten = FlattenConnector(poolOut, flat).apply { label = "Flatten" }
+            network.addNetworkModel(flatten, usePlacementManager = false)
+
+            // Row 6: TransformerBlock (matrices/sequences/attention/FF + white junction & multiply glyphs).
+            val tb = TransformerBlock(sequenceSize = 7, inputSize = 4, hiddenSize = 16).apply {
+                label = "Transformer"
+            }
+            network.addNetworkModel(tb, usePlacementManager = false)
+            tb.location = point(-600.0, 950.0)
+
+            // Row 6 right: ActivationSequence (sequence image + programmatic row highlight).
+            val seq = ActivationSequence(sequenceSize = 7, inputSize = 4).apply {
+                label = "Activation sequence 7x4"
+            }
+            network.addNetworkModel(seq, usePlacementManager = false)
+            seq.location = point(300.0, 950.0)
+            // Deterministic spread across the 7x4 activation matrix so the colormap shows hot/cool.
+            val seqMatrix = Matrix(7, 4)
+            for (r in 0 until 7) for (c in 0 until 4) {
+                seqMatrix[r, c] = (((r * 4 + c) % 7) - 3) / 3.0
+            }
+            seq.activations = seqMatrix
+            // Exercise the programmatic cyan row highlight.
+            seq.highlightedRows = setOf(seq.sequenceSize - 1)
+
+            // SKIPPED DeepNet: model class (kotlindl/DeepNet.kt), node class (DeepNetNode.kt), and the
+            // NetworkPanel.createNode dispatch for it are all commented out — it cannot be instantiated
+            // or rendered in the current build.
+        }
+
+        SwingUtilities.invokeAndWait {
+            JDialog().apply { contentPane = panel; pack() }
+            // Re-assert the harness theme, then run the live-recolor hook so every node recolors
+            // under it. This exercises the theme-switch path and is robust against the harness
+            // reinstalling a stale look-and-feel mid-build.
+            if (harnessDark) FlatDarkLaf.setup() else FlatLightLaf.setup()
+            panel.preferenceLoader()
+            network.events.zoomToFitPage.fire()
+        }
+        return panel
+    }
+}

--- a/src/snapshots/kotlin/org/simbrain/util/uisnapshot/KitchenSinkSnapshot.kt
+++ b/src/snapshots/kotlin/org/simbrain/util/uisnapshot/KitchenSinkSnapshot.kt
@@ -13,6 +13,7 @@ import org.simbrain.network.core.Neuron
 import org.simbrain.network.core.NeuronArray
 import org.simbrain.network.core.NeuronCollection
 import org.simbrain.network.core.Padding
+import org.simbrain.network.core.Synapse
 import org.simbrain.network.core.SynapseGroup
 import org.simbrain.network.core.TensorActivation
 import org.simbrain.network.core.TensorLayer
@@ -169,6 +170,24 @@ class KitchenSinkSnapshot : UiSnapshotDef {
                 displaySynapses = false  // -> directed green arrow
             }
             network.addNetworkModel(sg, usePlacementManager = false)
+
+            // Row 3 right: free neurons with synapses (weight ball + line + strength coloring),
+            // including a self-connection so the self-loop arc renders.
+            val fnA = Neuron().apply {
+                location = point(350.0, 60.0)
+                activation = 1.0
+            }
+            val fnB = Neuron().apply { location = point(500.0, 140.0) }
+            val fnC = Neuron().apply {
+                location = point(650.0, 60.0)
+                activation = -1.0
+            }
+            network.addNetworkModel(fnA, usePlacementManager = false)
+            network.addNetworkModel(fnB, usePlacementManager = false)
+            network.addNetworkModel(fnC, usePlacementManager = false)
+            network.addNetworkModel(Synapse(fnA, fnB, 1.0), usePlacementManager = false)
+            network.addNetworkModel(Synapse(fnB, fnC, -1.0), usePlacementManager = false)
+            network.addNetworkModel(Synapse(fnC, fnC, 0.5), usePlacementManager = false)
 
             // Row 4: SRN subnetwork (Outline + tab + 4 internal NeuronArray layers + weight matrices).
             val srn = SRNNetwork(

--- a/src/snapshots/kotlin/org/simbrain/util/uisnapshot/NetworkPanelThemeSwitchSnapshot.kt
+++ b/src/snapshots/kotlin/org/simbrain/util/uisnapshot/NetworkPanelThemeSwitchSnapshot.kt
@@ -1,0 +1,45 @@
+package org.simbrain.util.uisnapshot
+
+import com.formdev.flatlaf.FlatDarkLaf
+import kotlinx.coroutines.runBlocking
+import org.simbrain.network.NetworkComponent
+import org.simbrain.network.core.Network
+import org.simbrain.network.core.Neuron
+import org.simbrain.network.core.Synapse
+import org.simbrain.network.gui.NetworkPanel
+import org.simbrain.util.point
+import java.awt.Component
+import java.awt.Dimension
+import javax.swing.JDialog
+import javax.swing.SwingUtilities
+
+/**
+ * Builds the panel under the LIGHT theme (so its nodes are constructed with light colors), then
+ * installs the DARK look-and-feel and runs the live recolor hook ([NetworkPanel.preferenceLoader]).
+ * A correct dark result proves the live recolor path works (not just construction-time theming).
+ */
+class NetworkPanelThemeSwitchSnapshot : UiSnapshotDef {
+    override val name = "network_panel_theme_switch"
+
+    override fun build(): Component {
+        setupTheme("light")
+        val network = Network()
+        val component = NetworkComponent("snapshot", network)
+        val panel = NetworkPanel(component).apply { preferredSize = Dimension(600, 400) }
+        runBlocking {
+            val a = Neuron().apply { location = point(-80.0, 0.0) }
+            val b = Neuron().apply { location = point(80.0, 0.0) }
+            network.addNetworkModel(a, usePlacementManager = false)
+            network.addNetworkModel(b, usePlacementManager = false)
+            network.addNetworkModel(Synapse(a, b, 0.7), usePlacementManager = false)
+        }
+        SwingUtilities.invokeAndWait {
+            JDialog().apply { contentPane = panel; pack() }
+            network.events.zoomToFitPage.fire()
+            // Live theme switch: install the dark look-and-feel, then run the recolor hook.
+            FlatDarkLaf.setup()
+            panel.preferenceLoader()
+        }
+        return panel
+    }
+}

--- a/src/test/kotlin/org/simbrain/network/gui/nodes/NodeHandleThemeTest.kt
+++ b/src/test/kotlin/org/simbrain/network/gui/nodes/NodeHandleThemeTest.kt
@@ -1,0 +1,57 @@
+package org.simbrain.network.gui.nodes
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
+import org.simbrain.util.NetworkTheme
+import javax.swing.UIManager
+
+class NodeHandleThemeTest {
+
+    private inline fun withDarkMode(dark: Boolean, block: () -> Unit) {
+        val previous = UIManager.get("laf.dark")
+        try {
+            UIManager.put("laf.dark", dark)
+            block()
+        } finally {
+            UIManager.put("laf.dark", previous)
+        }
+    }
+
+    @Test
+    fun `selection and source handle styles carry the expected roles`() {
+        assertEquals(NodeHandle.Config.Role.SELECTION, NodeHandle.SELECTION_STYLE.role)
+        assertEquals(NodeHandle.Config.Role.SELECTION, NodeHandle.INTERACTION_BOX_SELECTION_STYLE.role)
+        assertEquals(NodeHandle.Config.Role.SOURCE, NodeHandle.SOURCE_STYLE.role)
+        assertEquals(NodeHandle.Config.Role.SOURCE, NodeHandle.INTERACTION_BOX_SOURCE_STYLE.role)
+    }
+
+    @Test
+    fun `handle color resolves to the themed palette color for its role in light mode`() {
+        withDarkMode(false) {
+            assertEquals(NetworkTheme.lightPalette.selectionHandle, NodeHandle.SELECTION_STYLE.resolveColor())
+            assertEquals(NetworkTheme.lightPalette.selectionHandle, NodeHandle.INTERACTION_BOX_SELECTION_STYLE.resolveColor())
+            assertEquals(NetworkTheme.lightPalette.sourceHandle, NodeHandle.SOURCE_STYLE.resolveColor())
+            assertEquals(NetworkTheme.lightPalette.sourceHandle, NodeHandle.INTERACTION_BOX_SOURCE_STYLE.resolveColor())
+        }
+    }
+
+    @Test
+    fun `handle color resolves to the themed palette color for its role in dark mode`() {
+        withDarkMode(true) {
+            assertEquals(NetworkTheme.darkPalette.selectionHandle, NodeHandle.SELECTION_STYLE.resolveColor())
+            assertEquals(NetworkTheme.darkPalette.sourceHandle, NodeHandle.SOURCE_STYLE.resolveColor())
+        }
+    }
+
+    @Test
+    fun `handle color tracks a live light-dark switch instead of being captured once`() {
+        withDarkMode(false) {
+            assertEquals(NetworkTheme.lightPalette.selectionHandle, NodeHandle.SELECTION_STYLE.resolveColor())
+        }
+        withDarkMode(true) {
+            assertEquals(NetworkTheme.darkPalette.selectionHandle, NodeHandle.SELECTION_STYLE.resolveColor())
+        }
+        assertNotEquals(NetworkTheme.lightPalette.selectionHandle, NetworkTheme.darkPalette.selectionHandle)
+    }
+}

--- a/src/test/kotlin/org/simbrain/util/ThemeColorPreferenceTest.kt
+++ b/src/test/kotlin/org/simbrain/util/ThemeColorPreferenceTest.kt
@@ -1,0 +1,79 @@
+package org.simbrain.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.awt.Color
+import kotlin.reflect.KMutableProperty1
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.jvm.isAccessible
+
+private object TestThemeColorPrefs : PreferenceHolder() {
+    var testThemeColorValue by ThemeColorPreference(
+        ThemeColor(Color(0x112233), Color(0xAABBCC), useManualDark = true)
+    )
+}
+
+private fun colorDelegate(): ThemeColorPreference =
+    TestThemeColorPrefs::class.declaredMemberProperties
+        .filterIsInstance<KMutableProperty1<Any, *>>()
+        .map { it.apply { isAccessible = true }.getDelegate(TestThemeColorPrefs) }
+        .filterIsInstance<ThemeColorPreference>()
+        .first()
+
+class ThemeColorPreferenceTest {
+
+    @Test
+    fun `resolve returns the light color in light mode and the manual dark color in dark mode`() {
+        val tc = ThemeColor(Color.RED, Color.BLUE, useManualDark = true)
+        assertEquals(Color.RED, tc.resolve(isDark = false))
+        assertEquals(Color.BLUE, tc.resolve(isDark = true))
+    }
+
+    @Test
+    fun `resolve infers the dark color when not manual`() {
+        val light = Color(0x3366CC)
+        val tc = ThemeColor(light, useManualDark = false)
+        assertEquals(light, tc.resolve(isDark = false))
+        assertEquals(inferDark(light), tc.resolve(isDark = true))
+    }
+
+    @Test
+    fun `inferDark darkens a light color and lightens a dark color`() {
+        val light = Color(0xE6E6E6)
+        val dark = Color(0x1A1A1A)
+        assertTrue(light.toHSL().third > inferDark(light).toHSL().third, "a light input should infer to a darker color")
+        assertTrue(dark.toHSL().third < inferDark(dark).toHSL().third, "a dark input should infer to a lighter color")
+    }
+
+    @Test
+    fun `ThemeColorPreference round-trips through serialize and deserialize`() {
+        val pref = ThemeColorPreference(ThemeColor(Color.GRAY))
+        val tc = ThemeColor(Color(0x010203), Color(0x040506), useManualDark = true)
+        assertEquals(tc, pref.deserialize(pref.serialize(tc)))
+    }
+
+    @Test
+    fun `committing the default does not pin the preference`() {
+        TestThemeColorPrefs.revertToDefault()
+        TestThemeColorPrefs.testThemeColorValue = colorDelegate().default
+        assertFalse(colorDelegate().isExplicitlySet())
+        TestThemeColorPrefs.revertToDefault()
+    }
+
+    @Test
+    fun `a customized theme color pins and then un-pins when returned to the default`() {
+        TestThemeColorPrefs.revertToDefault()
+        val custom = ThemeColor(Color(0x654321), Color(0x123456), useManualDark = true)
+
+        TestThemeColorPrefs.testThemeColorValue = custom
+        assertTrue(colorDelegate().isExplicitlySet())
+        assertEquals(custom, TestThemeColorPrefs.testThemeColorValue)
+
+        TestThemeColorPrefs.testThemeColorValue = colorDelegate().default
+        assertFalse(colorDelegate().isExplicitlySet())
+
+        TestThemeColorPrefs.revertToDefault()
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `NetworkTheme` palette so the Piccolo2D network canvas follows the FlatLaf light/dark mode, replacing hardcoded structural color literals (canvas background, node outlines, arrows, text, interaction boxes, selection chrome)
- Introduce a `ThemeColor` primitive holding a light/dark color pair, with automatic dark-variant inference (HSL-based) and a two-swatch preference editor widget (`ThemeColorSelector`); network color preferences migrate to `ThemeColorPreference`
- Live re-theming: theme switches propagate through `refreshThemedChrome` → `preferenceLoader` → a `refreshTheme` sweep over screen elements, so open networks recolor without restart
- Render Bezier/recurrent arrows as a single shape and theme canvas fonts; theme `RSyntaxTextArea` for light/dark
- Activation colormap now uses a 3-stop lerp so zero activation recedes into the canvas background
- New snapshot/regression tests: `KitchenSinkSnapshot`, `NetworkPanelThemeSwitchSnapshot`, `NodeHandleThemeTest`, `ThemeColorPreferenceTest`

## Test plan
- [ ] `./gradlew test`
- [ ] Visual check: toggle System/Light/Dark in Workspace Preferences with a network open; nodes, arrows, text, and selection chrome should recolor live
- [ ] uiSnapshot light/dark and theme-switch snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)