### PR TITLE
Repaint odor world on zoom and add an auto-zoom toggle

### DIFF
--- a/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldDesktopComponent.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldDesktopComponent.kt
@@ -58,7 +58,7 @@ class OdorWorldDesktopComponent(frame: GenericFrame, component: OdorWorldCompone
         val boxHeight = min(world.height.toInt() + offset.height, defaultMaxSize) - offset.height
         val content = lockedAspectRatio?.let { fitToBox(it, boxWidth, boxHeight) } ?: Dimension(boxWidth, boxHeight)
         parentFrame.preferredSize = Dimension(content.width + offset.width, content.height + offset.height)
-        SwingUtilities.invokeLater { worldPanel.scalingFactor = 1.0 }
+        SwingUtilities.invokeLater { if (worldPanel.autoZoom) worldPanel.zoomToFit() else worldPanel.scalingFactor = 1.0 }
         parentFrame.pack()
     }
 

--- a/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldMenus.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldMenus.kt
@@ -66,7 +66,8 @@ val OdorWorldPanel.viewMenu
             add(zoomInAction)
             add(zoomOutAction)
             add(resetZoomAction)
-            add(zoomToFitAction)
+            val autoZoomItem = JCheckBoxMenuItem(toggleAutoZoomAction)
+            add(autoZoomItem)
             addSeparator()
             val showTrails = JCheckBoxMenuItem(showAllTrailsAction)
             add(showTrails)
@@ -74,6 +75,7 @@ val OdorWorldPanel.viewMenu
             val showToolbar = JCheckBoxMenuItem(showToolbarAction)
             add(showToolbar)
             onMenuSelected {
+                autoZoomItem.isSelected = autoZoom
                 showTrails.isSelected = anyTrailShown
                 showToolbar.isSelected = mainToolBar.isVisible
             }

--- a/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldMenus.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldMenus.kt
@@ -66,6 +66,7 @@ val OdorWorldPanel.viewMenu
             add(zoomInAction)
             add(zoomOutAction)
             add(resetZoomAction)
+            add(zoomToFitAction)
             addSeparator()
             val showTrails = JCheckBoxMenuItem(showAllTrailsAction)
             add(showTrails)

--- a/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldPanel.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldPanel.kt
@@ -104,7 +104,17 @@ class OdorWorldPanel(
             val currentScalingFactor = canvas.camera.viewScale
             val scalingFactorRatio = scalingFactor / currentScalingFactor
             canvas.scale(scalingFactorRatio)
+            repaint()
         }
+
+    /**
+     * Zoom so the whole world is visible. Actions run off the Swing thread, so the repaint is requested explicitly
+     * rather than relying on Piccolo's paint invalidation, which only schedules a repaint from the event thread.
+     */
+    fun zoomToFit() {
+        canvas.setViewBounds(Rectangle2D.Double(0.0, 0.0, world.width, world.height))
+        repaint()
+    }
 
     fun debugToolTips() {
         if (tileSelectionModel != null) {
@@ -350,7 +360,7 @@ class OdorWorldPanel(
 
         world.events.tileMapChanged.fire()
 
-        canvas.setViewBounds(Rectangle2D.Double(0.0, 0.0, world.width, world.height))
+        zoomToFit()
 
         // Repaint whenever window is opened or changed. With the aspect lock on, a view that showed the whole
         // world before the resize keeps showing the whole world after it instead of drifting to a partial view.
@@ -359,7 +369,7 @@ class OdorWorldPanel(
                 val previousCanvasSize = lastCanvasSize
                 lastCanvasSize = canvas.size
                 if (world.lockAspectRatio && previousCanvasSize != null && showedWholeWorld(previousCanvasSize)) {
-                    canvas.setViewBounds(Rectangle2D.Double(0.0, 0.0, world.width, world.height))
+                    zoomToFit()
                 } else {
                     scalingFactor = scalingFactor // force invoke setter
                 }
@@ -585,6 +595,7 @@ class OdorWorldPanel(
             add(zoomInAction)
             add(zoomOutAction)
             add(resetZoomAction)
+            add(zoomToFitAction)
         }
     }
 

--- a/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldPanel.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/OdorWorldPanel.kt
@@ -2,6 +2,7 @@ package org.simbrain.world.odorworld
 
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.swing.Swing
 import org.piccolo2d.PCanvas
 import org.piccolo2d.PNode
 import org.piccolo2d.event.PBasicInputEventHandler
@@ -14,6 +15,7 @@ import org.simbrain.util.*
 import org.simbrain.util.piccolo.SceneGraphBrowser
 import org.simbrain.util.piccolo.Tile
 import org.simbrain.util.piccolo.setViewBoundsNoOverflow
+import org.simbrain.util.widgets.SimbrainToggleButton
 import org.simbrain.world.odorworld.dialogs.EntityDialog
 import org.simbrain.world.odorworld.entities.OdorWorldEntity
 import org.simbrain.world.odorworld.gui.*
@@ -30,6 +32,7 @@ import java.awt.geom.Rectangle2D
 import java.util.*
 import java.util.Timer
 import javax.swing.*
+import kotlin.math.abs
 import kotlin.math.min
 import kotlin.math.pow
 
@@ -115,6 +118,19 @@ class OdorWorldPanel(
         canvas.setViewBounds(Rectangle2D.Double(0.0, 0.0, world.width, world.height))
         repaint()
     }
+
+    /**
+     * When true the whole world is kept in view across resizes and world size changes, as with the network's
+     * auto-zoom. Manual zooming turns it off.
+     */
+    var autoZoom = true
+        set(value) {
+            field = value
+            world.events.zoomModeChanged.fire(value)
+            if (value) {
+                zoomToFit()
+            }
+        }
 
     fun debugToolTips() {
         if (tileSelectionModel != null) {
@@ -346,6 +362,9 @@ class OdorWorldPanel(
             override fun mouseWheelRotated(event: PInputEvent) {
                 val swingEvent = (event.sourceSwingEvent as MouseWheelEvent)
                 val newScale = 1.1.pow(swingEvent.preciseWheelRotation)
+                if (abs(swingEvent.preciseWheelRotation) > 2) {
+                    autoZoom = false
+                }
                 canvas.scale(1 / newScale)
             }
         })
@@ -362,13 +381,15 @@ class OdorWorldPanel(
 
         zoomToFit()
 
-        // Repaint whenever window is opened or changed. With the aspect lock on, a view that showed the whole
-        // world before the resize keeps showing the whole world after it instead of drifting to a partial view.
+        // Repaint whenever window is opened or changed. With auto-zoom on, or with the aspect lock on and a view
+        // that showed the whole world before the resize, the whole world stays in view instead of drifting to a
+        // partial view.
         addComponentListener(object : ComponentAdapter() {
             override fun componentResized(arg0: ComponentEvent) {
                 val previousCanvasSize = lastCanvasSize
                 lastCanvasSize = canvas.size
-                if (world.lockAspectRatio && previousCanvasSize != null && showedWholeWorld(previousCanvasSize)) {
+                val keepWholeWorld = world.lockAspectRatio && previousCanvasSize != null && showedWholeWorld(previousCanvasSize)
+                if (autoZoom || keepWholeWorld) {
                     zoomToFit()
                 } else {
                     scalingFactor = scalingFactor // force invoke setter
@@ -595,7 +616,16 @@ class OdorWorldPanel(
             add(zoomInAction)
             add(zoomOutAction)
             add(resetZoomAction)
-            add(zoomToFitAction)
+            add(SimbrainToggleButton(
+                icon = ResourceManager.getSmallIcon("menu_icons/ZoomFitPage.png"),
+                stateGetter = { autoZoom },
+                stateSetter = { autoZoom = it },
+                tooltipGenerator = { isOn -> "Auto-zoom is ${if (isOn) "on" else "off"}" }
+            ).apply {
+                world.events.zoomModeChanged.on(Dispatchers.Swing) {
+                    updateFromExternalState()
+                }
+            })
         }
     }
 

--- a/src/main/kotlin/org/simbrain/world/odorworld/events/OdorWorldEvents.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/events/OdorWorldEvents.kt
@@ -16,5 +16,6 @@ class OdorWorldEvents: FlowEvents() {
     val entityRemoved = OneArgEvent<OdorWorldEntity>()
     val tileMapChanged = NoArgEvent()
     val propertiesChanged = NoArgEvent()
+    val zoomModeChanged = OneArgEvent<Boolean>()
     val cleanups = HashMap<OdorWorldEntity, () -> Unit>()
 }

--- a/src/main/kotlin/org/simbrain/world/odorworld/gui/OdorWorldActions.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/gui/OdorWorldActions.kt
@@ -209,6 +209,15 @@ class OdorWorldActions(val odorWorldPanel: OdorWorldPanel) {
         scalingFactor /= 1.1
     }
 
+    val zoomToFitAction = odorWorldPanel.createAction(
+        name = "Zoom to fit",
+        description = "Zoom so the whole world is visible (Cmd/Ctrl-Shift-0)",
+        iconPath = "menu_icons/ZoomFitPage.png",
+        keyboardShortcut = CmdOrCtrl + KeyEvent.VK_0 + Shift
+    ) {
+        zoomToFit()
+    }
+
     val showToolbarAction = odorWorldPanel.createAction(
         name = "Toolbar",
         description = "Show or hide the toolbar"

--- a/src/main/kotlin/org/simbrain/world/odorworld/gui/OdorWorldActions.kt
+++ b/src/main/kotlin/org/simbrain/world/odorworld/gui/OdorWorldActions.kt
@@ -189,6 +189,7 @@ class OdorWorldActions(val odorWorldPanel: OdorWorldPanel) {
         keyboardShortcut = CmdOrCtrl + KeyEvent.VK_0
     ) {
         scalingFactor = 1.0
+        autoZoom = false
     }
 
     val zoomInAction = odorWorldPanel.createAction(
@@ -198,6 +199,7 @@ class OdorWorldActions(val odorWorldPanel: OdorWorldPanel) {
         keyboardShortcuts = listOf(CmdOrCtrl + KeyEvent.VK_ADD, CmdOrCtrl + KeyEvent.VK_EQUALS)
     ) {
         scalingFactor *= 1.1
+        autoZoom = false
     }
 
     val zoomOutAction = odorWorldPanel.createAction(
@@ -207,15 +209,15 @@ class OdorWorldActions(val odorWorldPanel: OdorWorldPanel) {
         keyboardShortcuts = listOf(CmdOrCtrl + KeyEvent.VK_SUBTRACT, CmdOrCtrl + KeyEvent.VK_MINUS)
     ) {
         scalingFactor /= 1.1
+        autoZoom = false
     }
 
-    val zoomToFitAction = odorWorldPanel.createAction(
-        name = "Zoom to fit",
-        description = "Zoom so the whole world is visible (Cmd/Ctrl-Shift-0)",
-        iconPath = "menu_icons/ZoomFitPage.png",
+    val toggleAutoZoomAction = odorWorldPanel.createAction(
+        name = "Auto-zoom",
+        description = "Keep the whole world in view (Cmd/Ctrl-Shift-0)",
         keyboardShortcut = CmdOrCtrl + KeyEvent.VK_0 + Shift
-    ) {
-        zoomToFit()
+    ) { event ->
+        autoZoom = (event?.source as? JCheckBoxMenuItem)?.state ?: !autoZoom
     }
 
     val showToolbarAction = odorWorldPanel.createAction(

--- a/src/test/kotlin/org/simbrain/world/odorworld/OdorWorldMenusTest.kt
+++ b/src/test/kotlin/org/simbrain/world/odorworld/OdorWorldMenusTest.kt
@@ -63,7 +63,7 @@ class OdorWorldMenusTest {
     @Test
     fun `view menu exposes zoom and trails`() {
         val labels = panel.viewMenu.itemLabels()
-        assertEquals(listOf("Zoom in", "Zoom out", "Reset zoom", "Show trails", "Toolbar"), labels)
+        assertEquals(listOf("Zoom in", "Zoom out", "Reset zoom", "Zoom to fit", "Show trails", "Toolbar"), labels)
     }
 
     @Test

--- a/src/test/kotlin/org/simbrain/world/odorworld/OdorWorldMenusTest.kt
+++ b/src/test/kotlin/org/simbrain/world/odorworld/OdorWorldMenusTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.simbrain.util.genericframe.GenericJInternalFrame
 import org.simbrain.workspace.gui.SimbrainDesktop
+import java.awt.event.ActionEvent
 import javax.swing.JMenu
 import javax.swing.SwingUtilities
 
@@ -63,7 +64,21 @@ class OdorWorldMenusTest {
     @Test
     fun `view menu exposes zoom and trails`() {
         val labels = panel.viewMenu.itemLabels()
-        assertEquals(listOf("Zoom in", "Zoom out", "Reset zoom", "Zoom to fit", "Show trails", "Toolbar"), labels)
+        assertEquals(listOf("Zoom in", "Zoom out", "Reset zoom", "Auto-zoom", "Show trails", "Toolbar"), labels)
+    }
+
+    @Test
+    fun `manual zoom turns auto-zoom off and toggling it back on fits the world`() {
+        SwingUtilities.invokeAndWait { panel.canvas.setSize(400, 300) }
+        assertTrue(panel.autoZoom)
+        SwingUtilities.invokeAndWait { panel.odorWorldActions.zoomInAction.actionPerformed(ActionEvent(panel, ActionEvent.ACTION_PERFORMED, null)) }
+        awaitOnEdt { !panel.autoZoom }
+        SwingUtilities.invokeAndWait { panel.odorWorldActions.toggleAutoZoomAction.actionPerformed(ActionEvent(panel, ActionEvent.ACTION_PERFORMED, null)) }
+        awaitOnEdt { panel.autoZoom }
+        awaitOnEdt {
+            val view = panel.canvas.camera.viewBounds
+            view.width >= world.width - 0.5 || view.height >= world.height - 0.5
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Odor world zoom in/out/reset didn't redraw the canvas until the next input event (e.g. moving the mouse into the panel). The action bodies run on the world's default dispatcher, so Piccolo's paint invalidation never scheduled a repaint. The scaling setter now calls `repaint()` explicitly, as the network panel does.
- Adds an **Auto-zoom** toggle like the network's: a toolbar toggle button, a View menu checkbox, and Cmd/Ctrl-Shift-0. While on, the whole world stays in view across frame resizes and world size changes. Zoom in/out/reset and larger mouse-wheel zooms turn it off; a new `zoomModeChanged` event keeps the toolbar button in sync.

## Test plan
- [x] `./gradlew test --tests "org.simbrain.world.odorworld.*"` (60 pass; menu-layout test updated, new toggle test added)
- [x] `uiSnapshot -PsnapshotDef=...OdorWorldMenusSnapshot` shows the toggle on the toolbar and the checkbox in View
- [ ] Manual: click zoom in/out with the mouse outside the panel and confirm the canvas updates immediately
- [ ] Manual: turn auto-zoom on, resize the frame, confirm the whole world stays in view

🤖 Generated with [Claude Code](https://claude.com/claude-code)